### PR TITLE
Add `%L` pattern to support millisecond [000..999]

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Formats the time according to the pre-compiled pattern, and returns the result s
 | %j      | the day of the year as a decimal number (001-366) |
 | %k      | the hour (24-hour clock) as a decimal number (0-23); single digits are preceded by a blank |
 | %l      | the hour (12-hour clock) as a decimal number (1-12); single digits are preceded by a blank |
+| %L      | the millisecond as a decimal number (000-999) |
 | %M      | the minute as a decimal number (00-59) |
 | %m      | the month as a decimal number (01-12) |
 | %n      | a newline |

--- a/strftime.go
+++ b/strftime.go
@@ -24,6 +24,7 @@ var (
 	dayOfYear                   = appenderFn(appendDayOfYear)
 	twentyFourHourClockSpacePad = hourwblank(false)
 	twelveHourClockSpacePad     = hourwblank(true)
+	millisecond                 = appenderFn(appendMillisecond)
 	minutesZeroPad              = timefmt("04")
 	monthNumberZeroPad          = timefmt("01")
 	newline                     = verbatim("\n")
@@ -82,6 +83,8 @@ func lookupDirective(key byte) (appender, bool) {
 		return twentyFourHourClockSpacePad, true
 	case 'l':
 		return twelveHourClockSpacePad, true
+	case 'L':
+		return millisecond, true
 	case 'M':
 		return minutesZeroPad, true
 	case 'm':

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var ref = time.Unix(1136239445, 0).UTC()
+var ref = time.Unix(1136239445, 123456789).UTC()
 
 func TestExclusion(t *testing.T) {
 	s, err := strftime.New("%p PM")
@@ -46,12 +46,12 @@ func TestFormat(t *testing.T) {
 
 	os.Setenv("LC_ALL", "C")
 
-	s, err := strftime.Format(`%A %a %B %b %C %c %D %d %e %F %H %h %I %j %k %l %M %m %n %p %R %r %S %T %t %U %u %V %v %W %w %X %x %Y %y %Z %z`, ref)
+	s, err := strftime.Format(`%A %a %B %b %C %c %D %d %e %F %H %h %I %j %k %l %L %M %m %n %p %R %r %S %T %t %U %u %V %v %W %w %X %x %Y %y %Z %z`, ref)
 	if !assert.NoError(t, err, `strftime.Format succeeds`) {
 		return
 	}
 
-	if !assert.Equal(t, "Monday Mon January Jan 20 Mon Jan  2 22:04:05 2006 01/02/06 02  2 2006-01-02 22 Jan 10 002 22 10 04 01 \n PM 22:04 10:04:05 PM 05 22:04:05 \t 01 1 01  2-Jan-2006 01 1 22:04:05 01/02/06 2006 06 UTC +0000", s, `formatted result matches`) {
+	if !assert.Equal(t, "Monday Mon January Jan 20 Mon Jan  2 22:04:05 2006 01/02/06 02  2 2006-01-02 22 Jan 10 002 22 10 123 04 01 \n PM 22:04 10:04:05 PM 05 22:04:05 \t 01 1 01  2-Jan-2006 01 1 22:04:05 01/02/06 2006 06 UTC +0000", s, `formatted result matches`) {
 		return
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -107,6 +107,17 @@ func appendCentury(b []byte, t time.Time) []byte {
 	return append(b, strconv.Itoa(n)...)
 }
 
+func appendMillisecond(b []byte, t time.Time) []byte {
+	millisecond := int(t.Nanosecond()) / int(time.Millisecond)
+	if millisecond < 100 {
+		b = append(b, '0')
+	}
+	if millisecond < 10 {
+		b = append(b, '0')
+	}
+	return append(b, strconv.Itoa(millisecond)...)
+}
+
 type weekday int
 
 func (v weekday) Append(b []byte, t time.Time) []byte {


### PR DESCRIPTION
But I'm not confident whether `%L` is a suitable to do it because that one is not supported by POSIX `strftime(3)`.
AFAIK, ruby provides `%L` and python provides `%f` for that.