### PR TITLE
Support `%s` pattern representing the Unix timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ type Appender interface {
 }
 ```
 
-For commonly used extensions such as the millisecond example, we provide a default
+For commonly used extensions such as the millisecond example and Unix timestamp, we provide a default
 implementation so the user can do one of the following:
 
 ```
-// (1) Pass a speficication byte and the Appender
+// (1) Pass a specification byte and the Appender
 //     This allows you to pass arbitrary Appenders
 p, err := strftime.New(
   `%L`,
@@ -132,6 +132,22 @@ p, err := strftime.New(
 p, err := strftime.New(
   `%L`,
   strftime.WithMilliseconds('L'),
+)
+```
+
+Similarly for Unix Timestamp:
+```
+// (1) Pass a specification byte and the Appender
+//     This allows you to pass arbitrary Appenders
+p, err := strftime.New(
+  `%s`,
+  strftime.WithSpecification('s', strftime.UnixSeconds),
+)
+
+// (2) Pass an option that knows to use strftime.UnixSeconds
+p, err := strftime.New(
+  `%s`,
+  strftime.WithUnixSeconds('s'),
 )
 ```
 

--- a/extension.go
+++ b/extension.go
@@ -10,6 +10,7 @@ import (
 // This way, `go doc -all` does not show the contents of the
 // milliseconds function
 var milliseconds Appender
+var unixseconds Appender
 
 func init() {
 	milliseconds = AppendFunc(func(b []byte, t time.Time) []byte {
@@ -22,10 +23,19 @@ func init() {
 		}
 		return append(b, strconv.Itoa(millisecond)...)
 	})
+	unixseconds = AppendFunc(func(b []byte, t time.Time) []byte {
+		return append(b, strconv.FormatInt(t.Unix(), 10)...)
+	})
 }
 
 // Milliseconds returns the Appender suitable for creating a zero-padded,
 // 3-digit millisecond textual representation.
-func Milliseconds()  Appender {
+func Milliseconds() Appender {
 	return milliseconds
+}
+
+// UnixSeconds returns the Appender suitable for creating
+// unix timestamp textual representation.
+func UnixSeconds() Appender {
+	return unixseconds
 }

--- a/options.go
+++ b/options.go
@@ -49,3 +49,11 @@ func WithSpecification(b byte, a Appender) Option {
 func WithMilliseconds(b byte) Option {
 	return WithSpecification(b, Milliseconds())
 }
+
+// WithUnixSeconds is similar to WithSpecification, and specifies that
+// the Strftime object should interpret the pattern `%b` (where b
+// is the byte that you specify as the argument)
+// as the unix timestamp in seconds
+func WithUnixSeconds(b byte) Option {
+	return WithSpecification(b, UnixSeconds())
+}

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -158,6 +158,15 @@ func TestGHPR7(t *testing.T) {
 	}
 }
 
+func TestWithUnixSeconds(t *testing.T) {
+	const expected = `1136239445`
+
+	p, _ := strftime.New(`%s`, strftime.WithUnixSeconds('s'))
+	if !assert.Equal(t, expected, p.FormatString(ref), `patterns should match for custom specification`) {
+		return
+	}
+}
+
 func Example_CustomSpecifications() {
 	{
 		// I want %L as milliseconds!
@@ -208,11 +217,23 @@ func Example_CustomSpecifications() {
 		os.Stdout.Write([]byte{'\n'})
 	}
 
+	{
+		// I want %s as unix timestamp!
+		p, err := strftime.New(`%s`, strftime.WithUnixSeconds('s'))
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		p.Format(os.Stdout, ref)
+		os.Stdout.Write([]byte{'\n'})
+	}
+
 	// OUTPUT:
 	// 123
 	// 123
 	// Daisuke Maki
 	// Daisuke Maki
+	// 1136239445
 }
 
 func TestGHIssue9(t *testing.T) {


### PR DESCRIPTION
Please could you consider this PR for a default implementation to produce a Unix timestamp?

`%s` is a standard pattern for a Unix timestamp, e.g in the [ubiquitous `date` CLI command ](http://man7.org/linux/man-pages/man1/date.1.html):

```
$ date '+%s'
1589032633
```


Why not just use [`Time.Unix` in golang's standard library](https://golang.org/pkg/time/#Time.Unix)?

==> Use of `Time.Unix` requires compile-time awareness of the time string format, or separate templating. I feel it's important to conveniently support a strftime pattern for Unix timestamp representation to cover cases where the pattern is only known at runtime e.g specified in an application's configuration file.

