### PR TITLE
Implement a microsecond extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ p, err := strftime.New(
 If a common specification is missing, please feel free to submit a PR
 (but please be sure to be able to defend how "common" it is)
 
+## List of available extensions
+
+- [`Milliseconds`](https://pkg.go.dev/github.com/lestrrat-go/strftime?tab=doc#Milliseconds) (related option: [`WithMilliseconds`](https://pkg.go.dev/github.com/lestrrat-go/strftime?tab=doc#WithMilliseconds));
+
+- [`Microseconds`](https://pkg.go.dev/github.com/lestrrat-go/strftime?tab=doc#Microseconds) (related option: [`WithMicroseconds`](https://pkg.go.dev/github.com/lestrrat-go/strftime?tab=doc#WithMicroseconds));
+
+- [`UnixSeconds`](https://pkg.go.dev/github.com/lestrrat-go/strftime?tab=doc#UnixSeconds) (related option: [`WithUnixSeconds`](https://pkg.go.dev/github.com/lestrrat-go/strftime?tab=doc#WithUnixSeconds)).
+
+
 # PERFORMANCE / OTHER LIBRARIES
 
 The following benchmarks were run separately because some libraries were using cgo on specific platforms (notabley, the fastly version)

--- a/extension.go
+++ b/extension.go
@@ -10,6 +10,7 @@ import (
 // This way, `go doc -all` does not show the contents of the
 // milliseconds function
 var milliseconds Appender
+var microseconds Appender
 var unixseconds Appender
 
 func init() {
@@ -23,6 +24,25 @@ func init() {
 		}
 		return append(b, strconv.Itoa(millisecond)...)
 	})
+	microseconds = AppendFunc(func(b []byte, t time.Time) []byte {
+		microsecond := int(t.Nanosecond()) / int(time.Microsecond)
+		if microsecond < 100000 {
+			b = append(b, '0')
+		}
+		if microsecond < 10000 {
+			b = append(b, '0')
+		}
+		if microsecond < 1000 {
+			b = append(b, '0')
+		}
+		if microsecond < 100 {
+			b = append(b, '0')
+		}
+		if microsecond < 10 {
+			b = append(b, '0')
+		}
+		return append(b, strconv.Itoa(microsecond)...)
+	})
 	unixseconds = AppendFunc(func(b []byte, t time.Time) []byte {
 		return append(b, strconv.FormatInt(t.Unix(), 10)...)
 	})
@@ -32,6 +52,12 @@ func init() {
 // 3-digit millisecond textual representation.
 func Milliseconds() Appender {
 	return milliseconds
+}
+
+// Microsecond returns the Appender suitable for creating a zero-padded,
+// 6-digit microsecond textual representation.
+func Microseconds() Appender {
+	return microseconds
 }
 
 // UnixSeconds returns the Appender suitable for creating

--- a/options.go
+++ b/options.go
@@ -50,6 +50,14 @@ func WithMilliseconds(b byte) Option {
 	return WithSpecification(b, Milliseconds())
 }
 
+// WithMicroseconds is similar to WithSpecification, and specifies that
+// the Strftime object should interpret the pattern `%b` (where b
+// is the byte that you specify as the argument)
+// as the zero-padded, 3 letter microseconds of the time.
+func WithMicroseconds(b byte) Option {
+	return WithSpecification(b, Microseconds())
+}
+
 // WithUnixSeconds is similar to WithSpecification, and specifies that
 // the Strftime object should interpret the pattern `%b` (where b
 // is the byte that you specify as the argument)

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -158,6 +158,15 @@ func TestGHPR7(t *testing.T) {
 	}
 }
 
+func TestWithMicroseconds(t *testing.T) {
+	const expected = `123456`
+
+	p, _ := strftime.New(`%f`, strftime.WithMicroseconds('f'))
+	if !assert.Equal(t, expected, p.FormatString(ref), `patterns should match for custom specification`) {
+		return
+	}
+}
+
 func TestWithUnixSeconds(t *testing.T) {
 	const expected = `1136239445`
 


### PR DESCRIPTION
The microsecond extension is available in e.g. Python's `strftime` as [`%f`](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes), and it is useful for e.g. profilers.