### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fast strftime for Go
 # SYNOPSIS
 
 ```go
-f := strftime.New(`.... pattern ...`)
+f, err := strftime.New(`.... pattern ...`)
 if err := f.Format(buf, time.Now()); err != nil {
     log.Println(err.Error())
 }


### PR DESCRIPTION
Thank you for this great library! I saw a small typo in the readme that can be a bit confusing for new users, so thought you'd want it fixed.