### PR TITLE
Add FormatBuffer

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	jehiah "github.com/jehiah/go-strftime"
 	fastly "github.com/fastly/go-utils/strftime"
+	jehiah "github.com/jehiah/go-strftime"
 	lestrrat "github.com/lestrrat-go/strftime"
 	tebeka "github.com/tebeka/strftime"
 )
@@ -67,12 +67,19 @@ func BenchmarkLestrratCachedWriter(b *testing.B) {
 	b.ResetTimer()
 
 	// This benchmark does not take into effect the compilation time
-	// nor the buffer reset time
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
 		buf.Reset()
-		b.StartTimer()
 		f.Format(&buf, t)
-		f.FormatString(t)
+	}
+}
+
+func BenchmarkLestrratCachedFormatBuffer(b *testing.B) {
+	var t time.Time
+	f, _ := lestrrat.New(benchfmt)
+	b.ResetTimer()
+
+	var buf []byte
+	for i := 0; i < b.N; i++ {
+		buf = f.FormatBuffer(buf[:0], t)
 	}
 }

--- a/strftime.go
+++ b/strftime.go
@@ -191,6 +191,13 @@ func (f *Strftime) Format(dst io.Writer, t time.Time) error {
 	return nil
 }
 
+// FormatBuffer is equivalent to Format, but appends the result directly to
+// supplied slice dst, returning the updated slice. This avoids any internal
+// memory allocation.
+func (f *Strftime) FormatBuffer(dst []byte, t time.Time) []byte {
+	return f.format(dst, t)
+}
+
 // Dump outputs the internal structure of the formatter, for debugging purposes.
 // Please do NOT assume the output format to be fixed: it is expected to change
 // in the future.


### PR DESCRIPTION
As discussed in [issue 25](https://github.com/lestrrat-go/strftime/issues/25), this is structurally similar to the standard library's `AppendFormat` method. I also fixed some issues with `BenchmarkLestrratCachedWriter` which made it look slower than it really was.

Nets about a 15% speedup which is less than I was hoping for, but still worth using in performance-intensive situations. Note the difference in the `time` output though - `FormatBuffer` uses about 20% less CPU time in total for the same number of executions, probably due to reduced garbage collection overhead.

```
[master][~/hound/go/src/github.com/ianwilkes/strftime/bench]$ time gotest . -bench BenchmarkLestrratCachedWriter -benchtime 30000000x
goos: darwin
goarch: amd64
pkg: github.com/lestrrat-go/strftime/bench
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkLestrratCachedWriter-8     30000000         390.1 ns/op
PASS
ok    github.com/lestrrat-go/strftime/bench 11.856s
gotest . -bench BenchmarkLestrratCachedWriter -benchtime 30000000x  12.69s user 1.07s system 111% cpu 12.299 total

[master][~/hound/go/src/github.com/ianwilkes/strftime/bench]$ time gotest . -bench BenchmarkLestrratCachedFormatBuffer -benchtime 30000000x
goos: darwin
goarch: amd64
pkg: github.com/lestrrat-go/strftime/bench
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkLestrratCachedFormatBuffer-8     30000000         330.3 ns/op
PASS
ok    github.com/lestrrat-go/strftime/bench 10.063s
gotest . -bench BenchmarkLestrratCachedFormatBuffer -benchtime 30000000x  10.49s user 0.62s system 105% cpu 10.517 total
```