### PR TITLE
fix midnight on 12-hour clocks

### DIFF
--- a/appenders.go
+++ b/appenders.go
@@ -291,6 +291,9 @@ func (v hourPadded) Append(b []byte, t time.Time) []byte {
 	if v.twelveHour && h > 12 {
 		h = h - 12
 	}
+	if v.twelveHour && h == 0 {
+		h = 12
+	}
 
 	if h < 10 {
 		b = append(b, v.pad)
@@ -322,7 +325,7 @@ func (v hmsWAMPM) Append(b []byte, t time.Time) []byte {
 		case h == 12:
 			// no op
 		case h > 12:
-			h = h -12
+			h = h - 12
 		default:
 			am = true
 		}
@@ -343,4 +346,3 @@ func (v hmsWAMPM) Append(b []byte, t time.Time) []byte {
 
 	return b
 }
-

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -275,9 +275,12 @@ func TestGHIssue18(t *testing.T) {
 			for i := 0; i < 24; i++ {
 				testTime := time.Date(2020, 1, 1, i, 1, 1, 1, time.UTC)
 				var correctString string
-				if twelveHour && i > 12 {
+				switch {
+				case twelveHour && i == 0:
+					correctString = fmt.Sprintf("%02d", 12)
+				case twelveHour && i > 12:
 					correctString = fmt.Sprintf("%02d", i-12)
-				} else {
+				default:
 					correctString = fmt.Sprintf("%02d", i)
 				}
 
@@ -322,4 +325,15 @@ func TestGHIssue18(t *testing.T) {
 	t.Run("12 hour zero pad %I", testIH(true))
 	t.Run("24 hour zero pad %H", testIH(false))
 	t.Run("12 hour zero pad %r", testR)
+}
+
+func TestFormat12AM(t *testing.T) {
+	s, err := strftime.Format(`%H %I %l`, time.Time{})
+	if !assert.NoError(t, err, `strftime.Format succeeds`) {
+		return
+	}
+
+	if !assert.Equal(t, "00 12 12", s, "correctly format the hour") {
+		return
+	}
 }


### PR DESCRIPTION
`%I` should have a range of 01-12, but this was formatting the zero hour as `00` which is incorrect.