### PR TITLE
replace deprecated package github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/lestrrat-go/strftime
 
-go 1.12
+go 1.13
 
 require (
 	github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/specifications.go
+++ b/specifications.go
@@ -1,10 +1,9 @@
 package strftime
 
 import (
+	"errors"
 	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 // because there is no such thing was a sync.RWLocker
@@ -124,7 +123,7 @@ func (ds *specificationSet) Lookup(b byte) (Appender, error) {
 	}
 	v, ok := ds.store[b]
 	if !ok {
-		return nil, errors.Errorf(`lookup failed: '%%%c' was not found in specification set`, b)
+		return nil, fmt.Errorf(`lookup failed: '%%%c' was not found in specification set`, b)
 	}
 	return v, nil
 }

--- a/strftime.go
+++ b/strftime.go
@@ -1,12 +1,12 @@
 package strftime
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 type compileHandler interface {
@@ -62,7 +62,7 @@ func compile(handler compileHandler, p string, ds SpecificationSet) error {
 
 		specification, err := ds.Lookup(p[1])
 		if err != nil {
-			return errors.Wrap(err, `pattern compilation failed`)
+			return fmt.Errorf(`pattern compilation failed: %w`, err)
 		}
 
 		handler.handle(specification)
@@ -127,14 +127,14 @@ func Format(p string, t time.Time, options ...Option) (string, error) {
 	// TODO: this may be premature optimization
 	ds, err := getSpecificationSetFor(options...)
 	if err != nil {
-		return "", errors.Wrap(err, `failed to get specification set`)
+		return "", fmt.Errorf("failed to get specification set: %w", err)
 	}
 	h := getFmtAppendExecutor()
 	defer releasdeFmtAppendExecutor(h)
 
 	h.t = t
 	if err := compile(h, p, ds); err != nil {
-		return "", errors.Wrap(err, `failed to compile format`)
+		return "", fmt.Errorf("failed to compile format: %w", err)
 	}
 
 	return string(h.dst), nil
@@ -152,14 +152,14 @@ func New(p string, options ...Option) (*Strftime, error) {
 	// TODO: this may be premature optimization
 	ds, err := getSpecificationSetFor(options...)
 	if err != nil {
-		return nil, errors.Wrap(err, `failed to get specification set`)
+		return nil, fmt.Errorf("failed to get specification set: %w", err)
 	}
 
 	var h appenderListBuilder
 	h.list = &combiningAppend{}
 
 	if err := compile(&h, p, ds); err != nil {
-		return nil, errors.Wrap(err, `failed to compile format`)
+		return nil, fmt.Errorf("failed to compile format: %w", err)
 	}
 
 	return &Strftime{


### PR DESCRIPTION
Replaces `github.com/pkg/errors`, which is now marked as archived and no longer maintained on github, with native >=go1.13 standard library functions. This preserves the error wrapping previously handled via `errors.Wrap` via the new `%w` directive in `fmt.Errorf`.

This makes the minimum go version go1.13, so thus update the go.mod to reflect and also updates the test matrix here to test from go1.13-go1.18 inclusive (previously tested go1.14-go1.15).