### PR TITLE
build(ci): test matrix include go1.12 up to go1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Install GolangCI-Lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
       - name: Test with coverage
         run: make cover
       - name: Upload code coverage to codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12' ]
+      fail-fast: false
     name: Go ${{ matrix.go }} test
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15', '1.14' ]
+        go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12' ]
     name: Go ${{ matrix.go }} test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Go stable version
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Install GolangCI-Lint
@@ -20,7 +20,7 @@ jobs:
       - name: Test with coverage
         run: make cover
       - name: Upload code coverage to codecov
-        if: matrix.go == '1.15'
+        if: matrix.go == '1.18'
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.out


### PR DESCRIPTION
This tests back from the version specified in go.mod to current stable.

This should enable detection of any breaking version changes as part of the dependencies update PR.

subtask forked from #28.