### PR TITLE
First phase of eradicating github.com/pkg/errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13' ]
         tags: [ 'strftime_native_errors', '' ]
       fail-fast: false
-    name: Go ${{ matrix.go }} test
+    name: Go ${{ matrix.go }} test (tags: ${{ matrix.tags }})
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13' ]
         tags: [ 'strftime_native_errors', '' ]
       fail-fast: false
-    name: Go ${{ matrix.go }} test (tags: ${{ matrix.tags }})
+    name: "Go ${{ matrix.go }} test (tags: ${{ matrix.tags }})"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12' ]
+        go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13' ]
       fail-fast: false
     name: Go ${{ matrix.go }} test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13' ]
+        tags: [ 'strftime_native_errors', '' ]
       fail-fast: false
     name: Go ${{ matrix.go }} test
     steps:
@@ -17,7 +18,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Test with coverage
-        run: make cover
+        run: make STRFTIME_TAGS=${{ matrix.tags }} cover
       - name: Upload code coverage to codecov
         if: matrix.go == '1.18'
         uses: codecov/codecov-action@v1

--- a/Changes
+++ b/Changes
@@ -1,6 +1,19 @@
 Changes
 =======
 
+v1.0.6 - UNRELEASED
+[Miscellaneous]
+  * github.com/pkg/errors is going to be phased out in steps. In this release,
+    users may opt-in to using native errors using `fmt.Errorf("%w")` by
+    specifying the tag `strftime_native_errors`. In the next release, the default
+    will be to use native errors, but users will be able to opt-in to using
+    github.com/pkg/errors using a tag. The version after will remove github.com/pkg/errors.
+
+    This is something that we normally would do over a major version upgrade
+    but since we do not expect this library to receive API breaking changes in the
+    near future and thus no v2 is expected, we have decided to do this over few
+    non-major releases.
+
 v1.0.5
 [New features]
   * `(strftime.Strftime).FormatBuffer([]byte, time.Time) []byte` has been added.

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Changes
 
 v1.0.6 - UNRELEASED
 [Miscellaneous]
+  * Minimum go version is now go 1.13
   * github.com/pkg/errors is going to be phased out in steps. In this release,
     users may opt-in to using native errors using `fmt.Errorf("%w")` by
     specifying the tag `strftime_native_errors`. In the next release, the default

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ test:
 	go test -v -race ./...
 
 cover:
+ifeq ($(strip $(STRFTIME_TAGS)),)
 	go test -v -race -coverpkg=./... -coverprofile=coverage.out ./...
+else
+	go test -v -tags $(STRFTIME_TAGS) -race -coverpkg=./... -coverprofile=coverage.out ./...
+endif
 
 viewcover:
 	go tool cover -html=coverage.out

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/lestrrat-go/strftime
 
-go 1.12
+go 1.13
 
 require (
 	github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/errors/errors_fmt.go
+++ b/internal/errors/errors_fmt.go
@@ -1,0 +1,13 @@
+//go:build strftime_native_errors
+
+package errors
+
+import "fmt"
+
+func New(s string) error {
+	return fmt.Errorf(s)
+}
+
+func Wrap(err error, s string) error {
+	return fmt.Errorf(s+`: %w`, err)
+}

--- a/internal/errors/errors_fmt.go
+++ b/internal/errors/errors_fmt.go
@@ -1,4 +1,5 @@
 //go:build strftime_native_errors
+// +build strftime_native_errors
 
 package errors
 

--- a/internal/errors/errors_fmt.go
+++ b/internal/errors/errors_fmt.go
@@ -9,6 +9,10 @@ func New(s string) error {
 	return fmt.Errorf(s)
 }
 
+func Errorf(s string, args ...interface{}) error {
+	return fmt.Errorf(s, args...)
+}
+
 func Wrap(err error, s string) error {
 	return fmt.Errorf(s+`: %w`, err)
 }

--- a/internal/errors/errors_pkg.go
+++ b/internal/errors/errors_pkg.go
@@ -9,6 +9,10 @@ func New(s string) error {
 	return errors.New(s)
 }
 
+func Errorf(s string, args ...interface{}) error {
+	return errors.Errorf(s, args...)
+}
+
 func Wrap(err error, s string) error {
 	return errors.Wrap(err, s)
 }

--- a/internal/errors/errors_pkg.go
+++ b/internal/errors/errors_pkg.go
@@ -1,4 +1,5 @@
 //go:build !strftime_native_errors
+// +build !strftime_native_errors
 
 package errors
 

--- a/internal/errors/errors_pkg.go
+++ b/internal/errors/errors_pkg.go
@@ -1,0 +1,13 @@
+//go:build !strftime_native_errors
+
+package errors
+
+import "github.com/pkg/errors"
+
+func New(s string) error {
+	return errors.New(s)
+}
+
+func Wrap(err error, s string) error {
+	return errors.Wrap(err, s)
+}

--- a/specifications.go
+++ b/specifications.go
@@ -1,9 +1,10 @@
 package strftime
 
 import (
-	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/lestrrat-go/strftime/internal/errors"
 )
 
 // because there is no such thing was a sync.RWLocker
@@ -123,7 +124,7 @@ func (ds *specificationSet) Lookup(b byte) (Appender, error) {
 	}
 	v, ok := ds.store[b]
 	if !ok {
-		return nil, fmt.Errorf(`lookup failed: '%%%c' was not found in specification set`, b)
+		return nil, errors.Errorf(`lookup failed: '%%%c' was not found in specification set`, b)
 	}
 	return v, nil
 }

--- a/specifications.go
+++ b/specifications.go
@@ -1,10 +1,9 @@
 package strftime
 
 import (
+	"errors"
 	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 // because there is no such thing was a sync.RWLocker
@@ -124,7 +123,7 @@ func (ds *specificationSet) Lookup(b byte) (Appender, error) {
 	}
 	v, ok := ds.store[b]
 	if !ok {
-		return nil, errors.Errorf(`lookup failed: '%%%c' was not found in specification set`, b)
+		return nil, fmt.Errorf(`lookup failed: '%%%c' was not found in specification set`, b)
 	}
 	return v, nil
 }

--- a/strftime.go
+++ b/strftime.go
@@ -1,12 +1,12 @@
 package strftime
 
 import (
-	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/lestrrat-go/strftime/internal/errors"
 )
 
 type compileHandler interface {
@@ -62,7 +62,7 @@ func compile(handler compileHandler, p string, ds SpecificationSet) error {
 
 		specification, err := ds.Lookup(p[1])
 		if err != nil {
-			return fmt.Errorf(`pattern compilation failed: %w`, err)
+			return errors.Wrap(err, `pattern compilation failed`)
 		}
 
 		handler.handle(specification)
@@ -127,14 +127,14 @@ func Format(p string, t time.Time, options ...Option) (string, error) {
 	// TODO: this may be premature optimization
 	ds, err := getSpecificationSetFor(options...)
 	if err != nil {
-		return "", fmt.Errorf("failed to get specification set: %w", err)
+		return "", errors.Wrap(err, `failed to get specification set`)
 	}
 	h := getFmtAppendExecutor()
 	defer releasdeFmtAppendExecutor(h)
 
 	h.t = t
 	if err := compile(h, p, ds); err != nil {
-		return "", fmt.Errorf("failed to compile format: %w", err)
+		return "", errors.Wrap(err, `failed to compile format`)
 	}
 
 	return string(h.dst), nil
@@ -152,14 +152,14 @@ func New(p string, options ...Option) (*Strftime, error) {
 	// TODO: this may be premature optimization
 	ds, err := getSpecificationSetFor(options...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get specification set: %w", err)
+		return nil, errors.Wrap(err, `failed to get specification set`)
 	}
 
 	var h appenderListBuilder
 	h.list = &combiningAppend{}
 
 	if err := compile(&h, p, ds); err != nil {
-		return nil, fmt.Errorf("failed to compile format: %w", err)
+		return nil, errors.Wrap(err, `failed to compile format`)
 	}
 
 	return &Strftime{

--- a/strftime.go
+++ b/strftime.go
@@ -1,12 +1,12 @@
 package strftime
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 type compileHandler interface {
@@ -62,7 +62,7 @@ func compile(handler compileHandler, p string, ds SpecificationSet) error {
 
 		specification, err := ds.Lookup(p[1])
 		if err != nil {
-			return errors.Wrap(err, `pattern compilation failed`)
+			return fmt.Errorf(`pattern compilation failed: %w`, err)
 		}
 
 		handler.handle(specification)
@@ -127,14 +127,14 @@ func Format(p string, t time.Time, options ...Option) (string, error) {
 	// TODO: this may be premature optimization
 	ds, err := getSpecificationSetFor(options...)
 	if err != nil {
-		return "", errors.Wrap(err, `failed to get specification set`)
+		return "", fmt.Errorf("failed to get specification set: %w", err)
 	}
 	h := getFmtAppendExecutor()
 	defer releasdeFmtAppendExecutor(h)
 
 	h.t = t
 	if err := compile(h, p, ds); err != nil {
-		return "", errors.Wrap(err, `failed to compile format`)
+		return "", fmt.Errorf("failed to compile format: %w", err)
 	}
 
 	return string(h.dst), nil
@@ -152,14 +152,14 @@ func New(p string, options ...Option) (*Strftime, error) {
 	// TODO: this may be premature optimization
 	ds, err := getSpecificationSetFor(options...)
 	if err != nil {
-		return nil, errors.Wrap(err, `failed to get specification set`)
+		return nil, fmt.Errorf("failed to get specification set: %w", err)
 	}
 
 	var h appenderListBuilder
 	h.list = &combiningAppend{}
 
 	if err := compile(&h, p, ds); err != nil {
-		return nil, errors.Wrap(err, `failed to compile format`)
+		return nil, fmt.Errorf("failed to compile format: %w", err)
 	}
 
 	return &Strftime{


### PR DESCRIPTION
First phase is to offer an opt-in path to using fmt.Errorf instead of github.com/pkg/errors

closes #28