### PR TITLE
Fix week number.

### DIFF
--- a/appenders.go
+++ b/appenders.go
@@ -36,13 +36,13 @@ var (
 	secondsNumberZeroPad        = StdlibFormat("05")
 	hms                         = StdlibFormat("15:04:05")
 	tab                         = Verbatim("\t")
-	weekNumberSundayOrigin      = weeknumberOffset(0) // week number of the year, Sunday first
+	weekNumberSundayOrigin      = weeknumberOffset(true) // week number of the year, Sunday first
 	weekdayMondayOrigin         = weekday(1)
 	// monday as the first day, and 01 as the first value
 	weekNumberMondayOriginOneOrigin = AppendFunc(appendWeekNumber)
 	eby                             = StdlibFormat("_2-Jan-2006")
 	// monday as the first day, and 00 as the first value
-	weekNumberMondayOrigin = weeknumberOffset(1) // week number of the year, Monday first
+	weekNumberMondayOrigin = weeknumberOffset(false) // week number of the year, Monday first
 	weekdaySundayOrigin    = weekday(0)
 	natReprTime            = StdlibFormat("15:04:05") // national representation of the time XXX is this correct?
 	natReprDate            = StdlibFormat("01/02/06") // national representation of the date XXX is this correct?
@@ -243,20 +243,16 @@ func (v weekday) Append(b []byte, t time.Time) []byte {
 	return append(b, byte(n+48))
 }
 
-type weeknumberOffset int
+type weeknumberOffset bool
 
 func (v weeknumberOffset) Append(b []byte, t time.Time) []byte {
-	yd := t.YearDay()
-	offset := int(t.Weekday()) - int(v)
-	if offset < 0 {
-		offset += 7
+	offset := int(t.Weekday())
+	if v {
+		offset = 6 - offset
+	} else if offset != 0 {
+		offset = 7 - offset
 	}
-
-	if yd < offset {
-		return append(b, '0', '0')
-	}
-
-	n := ((yd - offset) / 7) + 1
+	n := (t.YearDay() + offset) / 7
 	if n < 10 {
 		b = append(b, '0')
 	}

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -377,3 +377,27 @@ func TestFormat12AM(t *testing.T) {
 		return
 	}
 }
+
+func TestFormat_WeekNumber(t *testing.T) {
+	for y := 2000; y < 2020; y++ {
+		sunday := "00"
+		monday := "00"
+		for d := 1; d < 8; d++ {
+			base := time.Date(y, time.January, d, 0, 0, 0, 0, time.UTC)
+
+			switch base.Weekday() {
+			case time.Sunday:
+				sunday = "01"
+			case time.Monday:
+				monday = "01"
+			}
+
+			if got, _ := strftime.Format("%U", base); got != sunday {
+				t.Errorf("Format(%q, %d) = %q, want %q", "%U", base.Unix(), got, sunday)
+			}
+			if got, _ := strftime.Format("%W", base); got != monday {
+				t.Errorf("Format(%q, %d) = %q, want %q", "%W", base.Unix(), got, monday)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hi!

I created an alternative `strftime` implementation because I needed some additional things that'd be out of scope for this.
I lifted some of your tests (so thanks!) and was comparing performance, and noticed a mismatch in week number handling.

This PR adds my (exhaustive) unit test and fixes it here.

Without the fix the output is:
```sh
$ go test                        
--- FAIL: TestFormat_WeekNumber (0.00s)
    strftime_test.go:396: Format("%U", 978307200) = "01", want "00"
    strftime_test.go:396: Format("%U", 978393600) = "01", want "00"
    strftime_test.go:396: Format("%U", 978480000) = "01", want "00"
    strftime_test.go:396: Format("%U", 978566400) = "01", want "00"
    strftime_test.go:396: Format("%U", 978652800) = "01", want "00"
    strftime_test.go:396: Format("%U", 978739200) = "01", want "00"
    strftime_test.go:396: Format("%U", 978825600) = "02", want "01"
    strftime_test.go:399: Format("%W", 1009843200) = "01", want "00"
    strftime_test.go:399: Format("%W", 1009929600) = "01", want "00"
    strftime_test.go:399: Format("%W", 1010016000) = "01", want "00"
    strftime_test.go:399: Format("%W", 1010102400) = "01", want "00"
    strftime_test.go:399: Format("%W", 1010188800) = "01", want "00"
    strftime_test.go:399: Format("%W", 1010275200) = "01", want "00"
    strftime_test.go:399: Format("%W", 1010361600) = "02", want "01"
    strftime_test.go:396: Format("%U", 1167609600) = "01", want "00"
    strftime_test.go:396: Format("%U", 1167696000) = "01", want "00"
    strftime_test.go:396: Format("%U", 1167782400) = "01", want "00"
    strftime_test.go:396: Format("%U", 1167868800) = "01", want "00"
    strftime_test.go:396: Format("%U", 1167955200) = "01", want "00"
    strftime_test.go:396: Format("%U", 1168041600) = "01", want "00"
    strftime_test.go:396: Format("%U", 1168128000) = "02", want "01"
    strftime_test.go:399: Format("%W", 1199145600) = "01", want "00"
    strftime_test.go:399: Format("%W", 1199232000) = "01", want "00"
    strftime_test.go:399: Format("%W", 1199318400) = "01", want "00"
    strftime_test.go:399: Format("%W", 1199404800) = "01", want "00"
    strftime_test.go:399: Format("%W", 1199491200) = "01", want "00"
    strftime_test.go:399: Format("%W", 1199577600) = "01", want "00"
    strftime_test.go:399: Format("%W", 1199664000) = "02", want "01"
    strftime_test.go:399: Format("%W", 1356998400) = "01", want "00"
    strftime_test.go:399: Format("%W", 1357084800) = "01", want "00"
    strftime_test.go:399: Format("%W", 1357171200) = "01", want "00"
    strftime_test.go:399: Format("%W", 1357257600) = "01", want "00"
    strftime_test.go:399: Format("%W", 1357344000) = "01", want "00"
    strftime_test.go:399: Format("%W", 1357430400) = "01", want "00"
    strftime_test.go:399: Format("%W", 1357516800) = "02", want "01"
    strftime_test.go:396: Format("%U", 1514764800) = "01", want "00"
    strftime_test.go:396: Format("%U", 1514851200) = "01", want "00"
    strftime_test.go:396: Format("%U", 1514937600) = "01", want "00"
    strftime_test.go:396: Format("%U", 1515024000) = "01", want "00"
    strftime_test.go:396: Format("%U", 1515110400) = "01", want "00"
    strftime_test.go:396: Format("%U", 1515196800) = "01", want "00"
    strftime_test.go:396: Format("%U", 1515283200) = "02", want "01"
    strftime_test.go:399: Format("%W", 1546300800) = "01", want "00"
    strftime_test.go:399: Format("%W", 1546387200) = "01", want "00"
    strftime_test.go:399: Format("%W", 1546473600) = "01", want "00"
    strftime_test.go:399: Format("%W", 1546560000) = "01", want "00"
    strftime_test.go:399: Format("%W", 1546646400) = "01", want "00"
    strftime_test.go:399: Format("%W", 1546732800) = "01", want "00"
    strftime_test.go:399: Format("%W", 1546819200) = "02", want "01"
FAIL
exit status 1
FAIL    github.com/lestrrat-go/strftime 0.354s
```

You can validate my tests by running the following command, in macOS:
```sh
$ date -r 1546819200 +%W         
01
```

Or Linux:
```sh
$ date --date @1546819200 +%W         
01
```