### PR TITLE
Benchmark.

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -11,6 +11,7 @@ import (
 	fastly "github.com/fastly/go-utils/strftime"
 	jehiah "github.com/jehiah/go-strftime"
 	lestrrat "github.com/lestrrat-go/strftime"
+	ncruces "github.com/ncruces/go-strftime"
 	tebeka "github.com/tebeka/strftime"
 )
 
@@ -41,6 +42,21 @@ func BenchmarkFastly(b *testing.B) {
 	var t time.Time
 	for i := 0; i < b.N; i++ {
 		fastly.Strftime(benchfmt, t)
+	}
+}
+
+func BenchmarkNcruces(b *testing.B) {
+	var t time.Time
+	for i := 0; i < b.N; i++ {
+		ncruces.Format(benchfmt, t)
+	}
+}
+
+func BenchmarkNcrucesAppend(b *testing.B) {
+	var d []byte
+	var t time.Time
+	for i := 0; i < b.N; i++ {
+		d = ncruces.AppendFormat(d[:0], benchfmt, t)
 	}
 }
 

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869
-	github.com/lestrrat-go/strftime v1.0.3
+	github.com/lestrrat-go/strftime v1.0.6
+	github.com/ncruces/go-strftime v0.1.9
 	github.com/tebeka/strftime v0.1.5
 )


### PR DESCRIPTION
This adds my alternative `strftime` implementation to your benchmark. Feel free to ignore, just thought you might find it interesting.

Thanks for your [tests](https://github.com/ncruces/go-strftime/blob/369e6e84a966ead1ab44e8b030f523522de2ea27/external_test.go#L222-L239) and [benchmark](https://github.com/ncruces/go-strftime/blob/369e6e84a966ead1ab44e8b030f523522de2ea27/bench_test.go) that I used as guidance!

Results:
```sh
$ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/lestrrat-go/strftime/bench
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkTebeka-12                                420945              2858 ns/op             257 B/op         20 allocs/op
BenchmarkJehiah-12                                923040              1122 ns/op             256 B/op         17 allocs/op
BenchmarkFastly-12                               2920372               417.9 ns/op            80 B/op          5 allocs/op
BenchmarkNcruces-12                              2720719               425.7 ns/op            64 B/op          1 allocs/op
BenchmarkNcrucesAppend-12                        3047410               385.3 ns/op             0 B/op          0 allocs/op
BenchmarkLestrrat-12                              805414              1497 ns/op             288 B/op         15 allocs/op
BenchmarkLestrratCachedString-12                 3325786               350.9 ns/op           128 B/op          2 allocs/op
BenchmarkLestrratCachedWriter-12                 3544892               329.8 ns/op            64 B/op          1 allocs/op
BenchmarkLestrratCachedFormatBuffer-12           4147578               286.6 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/lestrrat-go/strftime/bench   15.200s
```