### PR TITLE
modernize CI and lint infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,29 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "daily"
     target-branch: "master"
+    labels:
+      - "go"
+      - "dependencies"
+      - "dependabot"
+  - package-ecosystem: "gomod"
+    directory: "/bench"
+    schedule:
+      interval: "daily"
+    target-branch: "master"
+    labels:
+      - "go"
+      - "dependencies"
+      - "dependabot"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     target-branch: "master"
-
+    labels:
+      - "github-actions"
+      - "dependencies"
+      - "dependabot"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,21 @@ jobs:
     name: "Go ${{ matrix.go }} test (tags: ${{ matrix.tags }})"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go }}-
       - name: Install Go stable version
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
+          check-latest: true
       - name: Test with coverage
         run: make STRFTIME_TAGS=${{ matrix.tags }} cover
       - name: Upload code coverage to codecov

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,14 +5,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.21
+          go-version-file: "go.mod"
           check-latest: true
-      - uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v1.60.1
+          version: v2.11.4
       - name: Run go vet
         run: |
           go vet ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,85 @@
+version: "2"
+linters:
+  default: all
+  disable:
+    - cyclop
+    - depguard
+    - dupl
+    - err113
+    - errorlint
+    - exhaustive
+    - funcorder
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - gosec
+    - gosmopolitan
+    - govet
+    - inamedparam
+    - ireturn
+    - lll
+    - maintidx
+    - makezero
+    - mnd
+    - nakedret
+    - nestif
+    - nlreturn
+    - noinlineerr
+    - nonamedreturns
+    - paralleltest
+    - perfsprint
+    - staticcheck
+    - recvcheck
+    - tagliatelle
+    - testifylint
+    - testpackage
+    - thelper
+    - varnamelen
+    - wrapcheck
+    - wsl
+    - wsl_v5
+  settings:
+    govet:
+      disable:
+        - shadow
+        - fieldalignment
+      enable-all: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - contextcheck
+          - exhaustruct
+        path: /*.go
+      - linters:
+          - errcheck
+          - errchkjson
+          - forcetypeassert
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bench realclean cover viewcover test lint
+.PHONY: bench realclean cover viewcover test lint imports
 
 bench:
 	go test -tags bench -benchmem -bench .

--- a/appenders.go
+++ b/appenders.go
@@ -210,8 +210,9 @@ type combiningAppend struct {
 
 func (ca *combiningAppend) Append(w Appender) {
 	if ca.prevCanCombine {
-		if wc, ok := w.(combiner); ok && wc.canCombine() {
-			ca.prev = ca.prev.(combiner).combine(wc)
+		prev, prevOK := ca.prev.(combiner)
+		if wc, ok := w.(combiner); ok && prevOK && wc.canCombine() {
+			ca.prev = prev.combine(wc)
 			ca.list[len(ca.list)-1] = ca.prev
 			return
 		}

--- a/extension.go
+++ b/extension.go
@@ -15,7 +15,7 @@ var unixseconds Appender
 
 func init() {
 	milliseconds = AppendFunc(func(b []byte, t time.Time) []byte {
-		millisecond := int(t.Nanosecond()) / int(time.Millisecond)
+		millisecond := t.Nanosecond() / int(time.Millisecond)
 		if millisecond < 100 {
 			b = append(b, '0')
 		}
@@ -25,7 +25,7 @@ func init() {
 		return append(b, strconv.Itoa(millisecond)...)
 	})
 	microseconds = AppendFunc(func(b []byte, t time.Time) []byte {
-		microsecond := int(t.Nanosecond()) / int(time.Microsecond)
+		microsecond := t.Nanosecond() / int(time.Microsecond)
 		if microsecond < 100000 {
 			b = append(b, '0')
 		}
@@ -54,7 +54,7 @@ func Milliseconds() Appender {
 	return milliseconds
 }
 
-// Microsecond returns the Appender suitable for creating a zero-padded,
+// Microseconds returns the Appender suitable for creating a zero-padded,
 // 6-digit microsecond textual representation.
 func Microseconds() Appender {
 	return microseconds

--- a/options.go
+++ b/options.go
@@ -2,20 +2,20 @@ package strftime
 
 type Option interface {
 	Name() string
-	Value() interface{}
+	Value() any
 }
 
 type option struct {
 	name  string
-	value interface{}
+	value any
 }
 
-func (o *option) Name() string       { return o.name }
-func (o *option) Value() interface{} { return o.value }
+func (o *option) Name() string { return o.name }
+func (o *option) Value() any   { return o.value }
 
 const optSpecificationSet = `opt-specification-set`
 
-// WithSpecification allows you to specify a custom specification set
+// WithSpecificationSet allows you to specify a custom specification set
 func WithSpecificationSet(ds SpecificationSet) Option {
 	return &option{
 		name:  optSpecificationSet,

--- a/specifications.go
+++ b/specifications.go
@@ -44,12 +44,12 @@ func newImmutableSpecificationSet() SpecificationSet {
 	// it can now be removed, but we would need to change the entire
 	// populateDefaultSpecifications method, and I'm currently too lazy
 	// PRs welcome)
-	tmp := NewSpecificationSet()
+	tmp := newSpecificationSet()
 
 	ss := &specificationSet{
 		mutable: false,
 		lock:    nil, // never used, so intentionally not initialized
-		store:   tmp.(*specificationSet).store,
+		store:   tmp.store,
 	}
 
 	return ss
@@ -57,6 +57,10 @@ func newImmutableSpecificationSet() SpecificationSet {
 
 // NewSpecificationSet creates a specification set with the default specifications.
 func NewSpecificationSet() SpecificationSet {
+	return newSpecificationSet()
+}
+
+func newSpecificationSet() *specificationSet {
 	ds := &specificationSet{
 		mutable: true,
 		lock:    &sync.RWMutex{},

--- a/strftime.go
+++ b/strftime.go
@@ -72,14 +72,18 @@ func compile(handler compileHandler, p string, ds SpecificationSet) error {
 }
 
 func getSpecificationSetFor(options ...Option) (SpecificationSet, error) {
-	var ds SpecificationSet = defaultSpecificationSet
+	ds := defaultSpecificationSet
 	var extraSpecifications []*optSpecificationPair
 	for _, option := range options {
 		switch option.Name() {
 		case optSpecificationSet:
-			ds = option.Value().(SpecificationSet)
+			if v, ok := option.Value().(SpecificationSet); ok {
+				ds = v
+			}
 		case optSpecification:
-			extraSpecifications = append(extraSpecifications, option.Value().(*optSpecificationPair))
+			if v, ok := option.Value().(*optSpecificationPair); ok {
+				extraSpecifications = append(extraSpecifications, v)
+			}
 		}
 	}
 
@@ -99,7 +103,7 @@ func getSpecificationSetFor(options ...Option) (SpecificationSet, error) {
 }
 
 var fmtAppendExecutorPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		var h appenderExecutor
 		h.dst = make([]byte, 0, 32)
 		return &h
@@ -107,7 +111,8 @@ var fmtAppendExecutorPool = sync.Pool{
 }
 
 func getFmtAppendExecutor() *appenderExecutor {
-	return fmtAppendExecutorPool.Get().(*appenderExecutor)
+	e, _ := fmtAppendExecutorPool.Get().(*appenderExecutor)
+	return e
 }
 
 func releasdeFmtAppendExecutor(v *appenderExecutor) {
@@ -178,12 +183,12 @@ func (f *Strftime) Pattern() string {
 func (f *Strftime) Format(dst io.Writer, t time.Time) error {
 	const bufSize = 64
 	var b []byte
-	max := len(f.pattern) + 10
-	if max < bufSize {
+	bufLen := len(f.pattern) + 10
+	if bufLen < bufSize {
 		var buf [bufSize]byte
 		b = buf[:0]
 	} else {
-		b = make([]byte, 0, max)
+		b = make([]byte, 0, bufLen)
 	}
 	if _, err := dst.Write(f.format(b, t)); err != nil {
 		return err
@@ -217,12 +222,12 @@ func (f *Strftime) format(b []byte, t time.Time) []byte {
 func (f *Strftime) FormatString(t time.Time) string {
 	const bufSize = 64
 	var b []byte
-	max := len(f.pattern) + 10
-	if max < bufSize {
+	bufLen := len(f.pattern) + 10
+	if bufLen < bufSize {
 		var buf [bufSize]byte
 		b = buf[:0]
 	} else {
-		b = make([]byte, 0, max)
+		b = make([]byte, 0, bufLen)
 	}
 	return string(f.format(b, t))
 }

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -46,7 +46,7 @@ func TestFormatMethods(t *testing.T) {
 	l := envload.New()
 	defer l.Restore()
 
-	os.Setenv("LC_ALL", "C")
+	t.Setenv("LC_ALL", "C")
 
 	formatString := `%A %a %B %b %C %c %D %d %e %F %H %h %I %j %k %l %M %m %n %p %R %r %S %T %t %U %u %V %v %W %w %X %x %Y %y %Z %z`
 	resultString := "Monday Mon January Jan 20 Mon Jan  2 22:04:05 2006 01/02/06 02  2 2006-01-02 22 Jan 10 002 22 10 04 01 \n PM 22:04 10:04:05 PM 05 22:04:05 \t 01 1 01  2-Jan-2006 01 1 22:04:05 01/02/06 2006 06 UTC +0000"
@@ -95,14 +95,13 @@ func TestFormatMethods(t *testing.T) {
 	if !assert.Equal(t, "nonsense"+resultString, string(dst), `appended result matches`) {
 		return
 	}
-
 }
 
 func TestFormatBlanks(t *testing.T) {
 	l := envload.New()
 	defer l.Restore()
 
-	os.Setenv("LC_ALL", "C")
+	t.Setenv("LC_ALL", "C")
 
 	{
 		dt := time.Date(1, 1, 1, 18, 0, 0, 0, time.UTC)
@@ -132,7 +131,7 @@ func TestFormatZeropad(t *testing.T) {
 	l := envload.New()
 	defer l.Restore()
 
-	os.Setenv("LC_ALL", "C")
+	t.Setenv("LC_ALL", "C")
 
 	{
 		dt := time.Date(1, 1, 1, 1, 0, 0, 0, time.UTC)
@@ -402,197 +401,196 @@ func TestFormat_WeekNumber(t *testing.T) {
 	}
 }
 
-
 func TestFormat_WeekYear(t *testing.T) {
-    // Note: According to ISO 8601, Week 1 is the week that contains the first Thursday of the year.
-    testCases := []struct {
-        name     string
-        date     time.Time
-        expectG  string // %G - ISO week year (4 digits)
-        expectg  string // %g - ISO week year without century (2 digits)
-    }{
-        {
-            name:     "New Year's Day 2005 (week belongs to 2004)",
-            date:     time.Date(2005, 1, 1, 0, 0, 0, 0, time.UTC), // Saturday
-            expectG:  "2004",
-            expectg:  "04",
-        },
-        {
-            name:     "New Year's Day 2006 (week belongs to 2005)", 
-            date:     time.Date(2006, 1, 1, 0, 0, 0, 0, time.UTC), // Sunday
-            expectG:  "2005",
-            expectg:  "05",
-        },
-        {
-            name:     "Dec 31, 2007 (week belongs to 2008)",
-            date:     time.Date(2007, 12, 31, 0, 0, 0, 0, time.UTC), // Monday
-            expectG:  "2008",
-            expectg:  "08",
-        },
-        {
-            name:     "Dec 30, 2008 (week belongs to 2009)",
-            date:     time.Date(2008, 12, 30, 0, 0, 0, 0, time.UTC), // Tuesday
-            expectG:  "2009",
-            expectg:  "09",
-        },
-        {
-            name:     "Jan 3, 2010 (first week of 2010)",
-            date:     time.Date(2010, 1, 3, 0, 0, 0, 0, time.UTC), // Sunday
-            expectG:  "2009",
-            expectg:  "09",
-        },
-        {
-            name:     "Jan 4, 2010 (first Monday, week 1 of 2010)",
-            date:     time.Date(2010, 1, 4, 0, 0, 0, 0, time.UTC), // Monday
-            expectG:  "2010",
-            expectg:  "10",
-        },
-        {
-            name:     "Regular date mid-year",
-            date:     time.Date(2023, 7, 15, 0, 0, 0, 0, time.UTC),
-            expectG:  "2023",
-            expectg:  "23",
-        },
-        {
-            name:     "Year 2000 (Y2K boundary)",
-            date:     time.Date(2000, 6, 15, 0, 0, 0, 0, time.UTC),
-            expectG:  "2000",
-            expectg:  "00",
-        },
-        {
-            name:     "Year 1999 to 2000 transition",
-            date:     time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), // Saturday
-            expectG:  "1999",
-            expectg:  "99",
-        },
-        {
-            name:     "Single digit year case",
-            date:     time.Date(2009, 6, 15, 0, 0, 0, 0, time.UTC),
-            expectG:  "2009",
-            expectg:  "09",
-        },
-        {
-            name:     "Edge case: Dec 29, 2014 (week 1 of 2015)",
-            date:     time.Date(2014, 12, 29, 0, 0, 0, 0, time.UTC), // Monday
-            expectG:  "2015",
-            expectg:  "15",
-        },
-        {
-            name:     "Edge case: Jan 4, 2021 (first Monday of year)",
-            date:     time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC), // Monday  
-            expectG:  "2021",
-            expectg:  "21",
-        },
-        {
-            name:     "Edge case: Jan 3, 2021 (belongs to 2020)",
-            date:     time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC), // Sunday
-            expectG:  "2020",
-            expectg:  "20",
-        },
-        // Test cases for BCE years
-        {
-            name:     "Year 1 BCE mid-year",
-            date:     time.Date(-1, 6, 15, 0, 0, 0, 0, time.UTC),
-            expectG:  "-0001",
-            expectg:  "-01",
-        },
-        {
-            name:     "Year 10 BCE",
-            date:     time.Date(-1, 3, 20, 0, 0, 0, 0, time.UTC),
-            expectG:  "-0001",
-            expectg:  "-01",
-        },
-        {
-            name:     "Year 99 BCE",
-            date:     time.Date(-99, 8, 10, 0, 0, 0, 0, time.UTC),
-            expectG:  "-0099",
-            expectg:  "-99",
-        },
-        {
-            name:     "Year 100 BCE (century boundary)",
-            date:     time.Date(-100, 12, 25, 0, 0, 0, 0, time.UTC),
-            expectG:  "-0100",
-            expectg:  "-00",
-        },
-        {
-            name:     "Year 1234 BCE (4-digit BCE year)",
-            date:     time.Date(-1234, 9, 15, 0, 0, 0, 0, time.UTC),
-            expectG:  "-1234",
-            expectg:  "-34",
-        },
-    }
+	// Note: According to ISO 8601, Week 1 is the week that contains the first Thursday of the year.
+	testCases := []struct {
+		name    string
+		date    time.Time
+		expectG string // %G - ISO week year (4 digits)
+		expectg string // %g - ISO week year without century (2 digits)
+	}{
+		{
+			name:    "New Year's Day 2005 (week belongs to 2004)",
+			date:    time.Date(2005, 1, 1, 0, 0, 0, 0, time.UTC), // Saturday
+			expectG: "2004",
+			expectg: "04",
+		},
+		{
+			name:    "New Year's Day 2006 (week belongs to 2005)",
+			date:    time.Date(2006, 1, 1, 0, 0, 0, 0, time.UTC), // Sunday
+			expectG: "2005",
+			expectg: "05",
+		},
+		{
+			name:    "Dec 31, 2007 (week belongs to 2008)",
+			date:    time.Date(2007, 12, 31, 0, 0, 0, 0, time.UTC), // Monday
+			expectG: "2008",
+			expectg: "08",
+		},
+		{
+			name:    "Dec 30, 2008 (week belongs to 2009)",
+			date:    time.Date(2008, 12, 30, 0, 0, 0, 0, time.UTC), // Tuesday
+			expectG: "2009",
+			expectg: "09",
+		},
+		{
+			name:    "Jan 3, 2010 (first week of 2010)",
+			date:    time.Date(2010, 1, 3, 0, 0, 0, 0, time.UTC), // Sunday
+			expectG: "2009",
+			expectg: "09",
+		},
+		{
+			name:    "Jan 4, 2010 (first Monday, week 1 of 2010)",
+			date:    time.Date(2010, 1, 4, 0, 0, 0, 0, time.UTC), // Monday
+			expectG: "2010",
+			expectg: "10",
+		},
+		{
+			name:    "Regular date mid-year",
+			date:    time.Date(2023, 7, 15, 0, 0, 0, 0, time.UTC),
+			expectG: "2023",
+			expectg: "23",
+		},
+		{
+			name:    "Year 2000 (Y2K boundary)",
+			date:    time.Date(2000, 6, 15, 0, 0, 0, 0, time.UTC),
+			expectG: "2000",
+			expectg: "00",
+		},
+		{
+			name:    "Year 1999 to 2000 transition",
+			date:    time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), // Saturday
+			expectG: "1999",
+			expectg: "99",
+		},
+		{
+			name:    "Single digit year case",
+			date:    time.Date(2009, 6, 15, 0, 0, 0, 0, time.UTC),
+			expectG: "2009",
+			expectg: "09",
+		},
+		{
+			name:    "Edge case: Dec 29, 2014 (week 1 of 2015)",
+			date:    time.Date(2014, 12, 29, 0, 0, 0, 0, time.UTC), // Monday
+			expectG: "2015",
+			expectg: "15",
+		},
+		{
+			name:    "Edge case: Jan 4, 2021 (first Monday of year)",
+			date:    time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC), // Monday
+			expectG: "2021",
+			expectg: "21",
+		},
+		{
+			name:    "Edge case: Jan 3, 2021 (belongs to 2020)",
+			date:    time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC), // Sunday
+			expectG: "2020",
+			expectg: "20",
+		},
+		// Test cases for BCE years
+		{
+			name:    "Year 1 BCE mid-year",
+			date:    time.Date(-1, 6, 15, 0, 0, 0, 0, time.UTC),
+			expectG: "-0001",
+			expectg: "-01",
+		},
+		{
+			name:    "Year 10 BCE",
+			date:    time.Date(-1, 3, 20, 0, 0, 0, 0, time.UTC),
+			expectG: "-0001",
+			expectg: "-01",
+		},
+		{
+			name:    "Year 99 BCE",
+			date:    time.Date(-99, 8, 10, 0, 0, 0, 0, time.UTC),
+			expectG: "-0099",
+			expectg: "-99",
+		},
+		{
+			name:    "Year 100 BCE (century boundary)",
+			date:    time.Date(-100, 12, 25, 0, 0, 0, 0, time.UTC),
+			expectG: "-0100",
+			expectg: "-00",
+		},
+		{
+			name:    "Year 1234 BCE (4-digit BCE year)",
+			date:    time.Date(-1234, 9, 15, 0, 0, 0, 0, time.UTC),
+			expectG: "-1234",
+			expectg: "-34",
+		},
+	}
 
-    for _, tc := range testCases {
-        t.Run(tc.name, func(t *testing.T) {
-            // Test %G (4-digit ISO week year)
-            gotG, err := strftime.Format("%G", tc.date)
-            if !assert.NoError(t, err, "strftime.Format %%G should succeed") {
-                return
-            }
-            if !assert.Equal(t, tc.expectG, gotG, "%%G format for %v", tc.date) {
-                return
-            }
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test %G (4-digit ISO week year)
+			gotG, err := strftime.Format("%G", tc.date)
+			if !assert.NoError(t, err, "strftime.Format %%G should succeed") {
+				return
+			}
+			if !assert.Equal(t, tc.expectG, gotG, "%%G format for %v", tc.date) {
+				return
+			}
 
-            // Test %g (2-digit ISO week year)
-            gotg, err := strftime.Format("%g", tc.date)
-            if !assert.NoError(t, err, "strftime.Format %%g should succeed") {
-                return
-            }
-            if !assert.Equal(t, tc.expectg, gotg, "%%g format for %v", tc.date) {
-                return
-            }
+			// Test %g (2-digit ISO week year)
+			gotg, err := strftime.Format("%g", tc.date)
+			if !assert.NoError(t, err, "strftime.Format %%g should succeed") {
+				return
+			}
+			if !assert.Equal(t, tc.expectg, gotg, "%%g format for %v", tc.date) {
+				return
+			}
 
-            // Verify consistency: last 2 digits of %G should equal %g
-            expectedLastG := tc.expectG[len(tc.expectG)-2:]
-            expectedLastg := tc.expectg[len(tc.expectg)-2:]
-            if !assert.Equal(t, expectedLastG, expectedLastg, "%%g should be last 2 digits of %%G for %v", tc.date) {
-                return
-            }
-        })
-    }
+			// Verify consistency: last 2 digits of %G should equal %g
+			expectedLastG := tc.expectG[len(tc.expectG)-2:]
+			expectedLastg := tc.expectg[len(tc.expectg)-2:]
+			if !assert.Equal(t, expectedLastG, expectedLastg, "%%g should be last 2 digits of %%G for %v", tc.date) {
+				return
+			}
+		})
+	}
 }
 
 func TestFormat_WeekYearBoundaries(t *testing.T) {
-    // Test the tricky boundary cases where calendar year != ISO week year
-    boundaryTests := []struct {
-        calendarYear int
-        month        time.Month
-        day          int
-        expectedWeekYear int
-    }{
-        // Cases where early January belongs to previous week year
-        {2005, time.January, 1, 2004}, // Sat Jan 1, 2005 is in week 53 of 2004
-        {2005, time.January, 2, 2004}, // Sun Jan 2, 2005 is in week 53 of 2004
-        {2006, time.January, 1, 2005}, // Sun Jan 1, 2006 is in week 52 of 2005
-        
-        // Cases where late December belongs to next week year  
-        {2007, time.December, 31, 2008}, // Mon Dec 31, 2007 is in week 1 of 2008
-        {2008, time.December, 29, 2009}, // Mon Dec 29, 2008 is in week 1 of 2009
-        {2008, time.December, 30, 2009}, // Tue Dec 30, 2008 is in week 1 of 2009
-        {2008, time.December, 31, 2009}, // Wed Dec 31, 2008 is in week 1 of 2009
-    }
+	// Test the tricky boundary cases where calendar year != ISO week year
+	boundaryTests := []struct {
+		calendarYear     int
+		month            time.Month
+		day              int
+		expectedWeekYear int
+	}{
+		// Cases where early January belongs to previous week year
+		{2005, time.January, 1, 2004}, // Sat Jan 1, 2005 is in week 53 of 2004
+		{2005, time.January, 2, 2004}, // Sun Jan 2, 2005 is in week 53 of 2004
+		{2006, time.January, 1, 2005}, // Sun Jan 1, 2006 is in week 52 of 2005
 
-    for _, bt := range boundaryTests {
-        testDate := time.Date(bt.calendarYear, bt.month, bt.day, 0, 0, 0, 0, time.UTC)
-        
-        gotG, err := strftime.Format("%G", testDate)
-        if !assert.NoError(t, err, "strftime.Format %%G should succeed") {
-            continue
-        }
-        
-        expectedG := fmt.Sprintf("%04d", bt.expectedWeekYear)
-        if !assert.Equal(t, expectedG, gotG, "Calendar %d-%02d-%02d should be week year %d", 
-            bt.calendarYear, bt.month, bt.day, bt.expectedWeekYear) {
-            continue
-        }
-        
-        // Test %g as well
-        gotg, err := strftime.Format("%g", testDate)
-        if !assert.NoError(t, err, "strftime.Format %%g should succeed") {
-            continue
-        }
-        
-        expectedg := fmt.Sprintf("%02d", bt.expectedWeekYear%100)
-        assert.Equal(t, expectedg, gotg, "Week year without century should match for %v", testDate)
-    }
+		// Cases where late December belongs to next week year
+		{2007, time.December, 31, 2008}, // Mon Dec 31, 2007 is in week 1 of 2008
+		{2008, time.December, 29, 2009}, // Mon Dec 29, 2008 is in week 1 of 2009
+		{2008, time.December, 30, 2009}, // Tue Dec 30, 2008 is in week 1 of 2009
+		{2008, time.December, 31, 2009}, // Wed Dec 31, 2008 is in week 1 of 2009
+	}
+
+	for _, bt := range boundaryTests {
+		testDate := time.Date(bt.calendarYear, bt.month, bt.day, 0, 0, 0, 0, time.UTC)
+
+		gotG, err := strftime.Format("%G", testDate)
+		if !assert.NoError(t, err, "strftime.Format %%G should succeed") {
+			continue
+		}
+
+		expectedG := fmt.Sprintf("%04d", bt.expectedWeekYear)
+		if !assert.Equal(t, expectedG, gotG, "Calendar %d-%02d-%02d should be week year %d",
+			bt.calendarYear, bt.month, bt.day, bt.expectedWeekYear) {
+			continue
+		}
+
+		// Test %g as well
+		gotg, err := strftime.Format("%g", testDate)
+		if !assert.NoError(t, err, "strftime.Format %%g should succeed") {
+			continue
+		}
+
+		expectedg := fmt.Sprintf("%02d", bt.expectedWeekYear%100)
+		assert.Equal(t, expectedg, gotg, "Week year without century should match for %v", testDate)
+	}
 }


### PR DESCRIPTION
- migrate `.golangci.yml` to golangci-lint v2 format (mirrors jwx)
- bump lint workflow to golangci-lint-action v9.2.0 / lint v2.11.4, use `go-version-file`
- add Go module caching to CI, bump checkout/setup-go action SHAs
- add `/bench` module + labels to dependabot
- fix all findings from the new linter (any, checked type assertions, doc/format fixes); no public API or behavior change

go.mod stays at `go 1.21`; CI Go matrix unchanged.
