### PR TITLE
support no-padding flag for numeric specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ Formats the time according to the pre-compiled pattern, and returns the result s
 | %z      | the time zone offset from UTC |
 | %%      | a '%' |
 
+# NO-PADDING FLAG
+
+A `-` (glibc) or `#` (Windows) flag may be placed between the `%` and the
+conversion specifier to suppress the leading zero/blank padding on numeric
+fields. For example, given `2006-01-02 03:04:05`:
+
+| pattern | result |
+|---------|--------|
+| %m      | 01     |
+| %-m     | 1      |
+| %d      | 02     |
+| %-d     | 2      |
+| %H:%M   | 03:04  |
+| %-H:%-M | 3:4    |
+
+The flag has no effect on non-numeric fields (e.g. `%-A` is identical to `%A`).
+
 # EXTENSIONS / CUSTOM SPECIFICATIONS
 
 This library in general tries to be POSIX compliant, but sometimes you just need that

--- a/appenders.go
+++ b/appenders.go
@@ -171,6 +171,49 @@ func (v verbatimw) dump(out io.Writer) {
 	fmt.Fprintf(out, "verbatim: %s", v.s)
 }
 
+// unpadded wraps another Appender and strips the padding from the value it
+// produces. It implements the glibc '-' and Windows '#' flags, which suppress
+// the leading zeros or spaces on numeric fields (e.g. %-d -> "1" instead of
+// "01"). Non-numeric fields are emitted unchanged, matching libc behavior.
+type unpadded struct {
+	inner Appender
+}
+
+func (v unpadded) Append(b []byte, t time.Time) []byte {
+	var buf [64]byte
+	s := v.inner.Append(buf[:0], t)
+
+	// drop leading spaces (space-padded fields such as %e, %k, %l)
+	i := 0
+	for i < len(s) && s[i] == ' ' {
+		i++
+	}
+	s = s[i:]
+
+	// keep a leading sign, if any (e.g. the "+"/"-" of %z)
+	if len(s) > 0 && (s[0] == '+' || s[0] == '-') {
+		b = append(b, s[0])
+		s = s[1:]
+	}
+
+	// drop leading zeros, but always keep at least one digit
+	j := 0
+	for j < len(s)-1 && s[j] == '0' {
+		j++
+	}
+	return append(b, s[j:]...)
+}
+
+func (v unpadded) dump(out io.Writer) {
+	fmt.Fprintf(out, "unpadded[")
+	if d, ok := v.inner.(dumper); ok {
+		d.dump(out)
+	} else {
+		fmt.Fprintf(out, "%#v", v.inner)
+	}
+	fmt.Fprintf(out, "]")
+}
+
 // These words below, as well as any decimal character
 var combineExclusion = []string{
 	"Mon",

--- a/strftime.go
+++ b/strftime.go
@@ -60,13 +60,29 @@ func compile(handler compileHandler, p string, ds SpecificationSet) error {
 			p = p[i:]
 		}
 
-		specification, err := ds.Lookup(p[1])
+		// An optional '-' (glibc) or '#' (Windows) flag between the '%' and
+		// the conversion specifier suppresses padding on numeric fields.
+		specIdx := 1
+		var noPad bool
+		if c := p[1]; c == '-' || c == '#' {
+			if len(p) < 3 {
+				return errors.New(`stray % at the end of pattern`)
+			}
+			noPad = true
+			specIdx = 2
+		}
+
+		specification, err := ds.Lookup(p[specIdx])
 		if err != nil {
 			return fmt.Errorf("pattern compilation failed: %w", err)
 		}
 
+		if noPad {
+			specification = unpadded{inner: specification}
+		}
+
 		handler.handle(specification)
-		p = p[2:]
+		p = p[specIdx+1:]
 	}
 	return nil
 }

--- a/unpadded_test.go
+++ b/unpadded_test.go
@@ -1,0 +1,72 @@
+package strftime_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/strftime"
+	"github.com/stretchr/testify/require"
+)
+
+// unpadref is chosen so that every numeric field has a single significant
+// digit, making the effect of the '-'/'#' (no-pad) flag observable.
+// 2006-01-02 03:04:05 UTC: Jan(01) 2nd(02) 03:04:05, year-of-century 06,
+// day-of-year 002, UTC offset +0000.
+var unpadref = time.Date(2006, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+func TestUnpaddedFlag(t *testing.T) {
+	for _, tc := range []struct {
+		spec     byte
+		padded   string
+		unpadded string
+	}{
+		{'d', "02", "2"},
+		{'e', " 2", "2"},
+		{'H', "03", "3"},
+		{'I', "03", "3"},
+		{'j', "002", "2"},
+		{'k', " 3", "3"},
+		{'l', " 3", "3"},
+		{'M', "04", "4"},
+		{'m', "01", "1"},
+		{'S', "05", "5"},
+		{'y', "06", "6"},
+		{'z', "+0000", "+0"},
+	} {
+		t.Run(string(tc.spec), func(t *testing.T) {
+			padded, err := strftime.Format("%"+string(tc.spec), unpadref)
+			require.NoError(t, err, "padded form should compile")
+			require.Equal(t, tc.padded, padded, "padded baseline")
+
+			for _, flag := range []string{"-", "#"} {
+				got, err := strftime.Format("%"+flag+string(tc.spec), unpadref)
+				require.NoErrorf(t, err, "%%%s%c should compile", flag, tc.spec)
+				require.Equalf(t, tc.unpadded, got, "%%%s%c", flag, tc.spec)
+			}
+		})
+	}
+}
+
+func TestUnpaddedNonNumericUnchanged(t *testing.T) {
+	// Non-numeric fields are emitted unchanged when the flag is present.
+	for _, spec := range []string{"A", "B", "Z", "p"} {
+		plain, err := strftime.Format("%"+spec, unpadref)
+		require.NoError(t, err)
+		flagged, err := strftime.Format("%-"+spec, unpadref)
+		require.NoError(t, err)
+		require.Equalf(t, plain, flagged, "%%-%s should match %%%s", spec, spec)
+	}
+}
+
+func TestUnpaddedInContext(t *testing.T) {
+	got, err := strftime.Format("%Y-%-m-%-d %-H:%-M:%-S", unpadref)
+	require.NoError(t, err)
+	require.Equal(t, "2006-1-2 3:4:5", got)
+}
+
+func TestUnpaddedStrayFlag(t *testing.T) {
+	for _, p := range []string{"%-", "%#", "foo %-"} {
+		_, err := strftime.Format(p, unpadref)
+		require.Errorf(t, err, "pattern %q should error", p)
+	}
+}


### PR DESCRIPTION
- add `-` (glibc) / `#` (Windows) flag between `%` and specifier to suppress zero/blank padding on numeric fields (closes #13)
- `unpadded` Appender strips leading zeros/spaces, preserves sign for `%z`, leaves non-numeric fields unchanged
- table-driven tests from the issue's libc reference output + README docs
