### PR TITLE
add locale support for name specifiers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters:
           - errcheck
           - errchkjson
           - forcetypeassert
+          - goconst
         path: _test\.go
     paths:
       - third_party$

--- a/README.md
+++ b/README.md
@@ -88,6 +88,47 @@ Formats the time according to the pre-compiled pattern, and returns the result s
 | %z      | the time zone offset from UTC |
 | %%      | a '%' |
 
+# LOCALIZATION
+
+By default the name-producing specifiers (`%A`, `%a`, `%B`, `%b`, `%h`, `%p`)
+emit English. To localize them, pass a `Locale` via `WithLocale`. The library
+ships no locale data of its own — you supply the names for your language:
+
+```go
+french := strftime.Locale{
+  Months: strftime.MonthNames{
+    "janvier", "février", "mars", "avril", "mai", "juin",
+    "juillet", "août", "septembre", "octobre", "novembre", "décembre",
+  },
+  Weekdays: strftime.WeekdayNames{
+    "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
+  },
+  // ShortMonths, ShortWeekdays, AMPM ... optional
+}
+
+s, _ := strftime.New(`%A %d %B %Y`, strftime.WithLocale(french))
+// -> "lundi 02 janvier 2006"
+```
+
+`MonthNames` is indexed by month minus one (January is index 0); `WeekdayNames`
+is indexed by `time.Weekday` (Sunday is index 0). Any name left empty falls
+back to the English default, so a partial `Locale` never yields blank output.
+Numeric specifiers (`%d`, `%m`, `%Y`, ...) are locale-invariant and unaffected.
+Start from `strftime.DefaultLocale()` if you want to override only a few names.
+
+## Inflected languages
+
+In some languages (Russian, Czech, Polish, Greek, ...) a month name changes
+form depending on whether it stands alone or appears next to a day number —
+e.g. Russian "январь" (stand-alone) vs "2 января" (in a date). Because a single
+`Locale` carries one form per name, format each context with its own compiled
+`Strftime`:
+
+```go
+inDate, _   := strftime.New(`%d %B %Y`, strftime.WithLocale(ruInDate))   // января
+header, _   := strftime.New(`%B %Y`,    strftime.WithLocale(ruStandalone)) // январь
+```
+
 # EXTENSIONS / CUSTOM SPECIFICATIONS
 
 This library in general tries to be POSIX compliant, but sometimes you just need that

--- a/README.md
+++ b/README.md
@@ -91,20 +91,21 @@ Formats the time according to the pre-compiled pattern, and returns the result s
 # LOCALIZATION
 
 By default the name-producing specifiers (`%A`, `%a`, `%B`, `%b`, `%h`, `%p`)
-emit English. To localize them, pass a `Locale` via `WithLocale`. The library
-ships no locale data of its own — you supply the names for your language:
+emit English. To localize them, build a `Locale` with `NewLocale` and pass it
+via `WithLocale`. The library ships no locale data of its own — you supply the
+names for your language:
 
 ```go
-french := strftime.Locale{
-  Months: strftime.MonthNames{
+french := strftime.NewLocale(
+  strftime.WithMonths(strftime.MonthNames{
     "janvier", "février", "mars", "avril", "mai", "juin",
     "juillet", "août", "septembre", "octobre", "novembre", "décembre",
-  },
-  Weekdays: strftime.WeekdayNames{
+  }),
+  strftime.WithWeekdays(strftime.WeekdayNames{
     "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
-  },
-  // ShortMonths, ShortWeekdays, AMPM ... optional
-}
+  }),
+  // WithShortMonths, WithShortWeekdays, WithMeridiem ... optional
+)
 
 s, _ := strftime.New(`%A %d %B %Y`, strftime.WithLocale(french))
 // -> "lundi 02 janvier 2006"
@@ -114,7 +115,10 @@ s, _ := strftime.New(`%A %d %B %Y`, strftime.WithLocale(french))
 is indexed by `time.Weekday` (Sunday is index 0). Any name left empty falls
 back to the English default, so a partial `Locale` never yields blank output.
 Numeric specifiers (`%d`, `%m`, `%Y`, ...) are locale-invariant and unaffected.
-Start from `strftime.DefaultLocale()` if you want to override only a few names.
+
+`Locale` is an interface, so you can also implement it yourself to back the
+names with a map, computed values, or an external dataset. `DefaultLocale()`
+returns the English implementation.
 
 ## Inflected languages
 

--- a/locale.go
+++ b/locale.go
@@ -6,90 +6,139 @@ import (
 	"time"
 )
 
-// MonthNames holds the twelve localized month names, indexed by
-// time.Month minus one (January is index 0, December is index 11).
+// MonthNames holds twelve month names, indexed by time.Month minus one
+// (January is index 0, December is index 11). It is used as the argument to
+// WithMonths and WithShortMonths.
 type MonthNames [12]string
 
-// WeekdayNames holds the seven localized weekday names, indexed by
-// time.Weekday (Sunday is index 0, Saturday is index 6).
+// WeekdayNames holds seven weekday names, indexed by time.Weekday (Sunday is
+// index 0, Saturday is index 6). It is used as the argument to WithWeekdays
+// and WithShortWeekdays.
 type WeekdayNames [7]string
 
-// Locale carries the locale-dependent strings used by the name-producing
-// conversion specifiers (%A, %a, %B, %b, %h, %p). It contains no logic and
-// no external data: you populate it with the names for your language and
-// pass it via WithLocale.
+// Locale supplies the locale-dependent strings used by the name-producing
+// conversion specifiers (%A, %a, %B, %b, %h, %p). The library ships no locale
+// data of its own: build a Locale for your language with NewLocale, or
+// implement this interface yourself to back it with any source (a map,
+// computed values, an external CLDR dataset, ...).
 //
-// Month and weekday names are split into a "format" context and a
-// "stand-alone" context. In many languages (Russian, Czech, Polish, Greek,
-// ...) a month name takes a different grammatical form when it appears next
-// to a day number ("2 января") than when it stands alone ("январь"). The
-// format fields (Months, ShortMonths) hold the in-date form; the standalone
-// fields hold the nominative form.
+// Months are addressed by time.Month and weekdays by time.Weekday, so an
+// implementation never has to worry about index conventions.
 //
-// Only the format fields are currently reachable through the standard
-// conversion specifiers. To format the two contexts correctly today, compile
-// two Strftime objects with two Locales — one whose Months hold the in-date
-// form for patterns like "%-d %B", and one whose Months hold the stand-alone
-// form for patterns like "%B %Y". The standalone fields are reserved for a
-// future %OB/%Ob specifier and may be left zero if you do not need them.
-//
-// Any entry left as the empty string falls back to the English default, so a
-// partially-filled Locale never produces blank output.
-type Locale struct {
-	Months      MonthNames // %B — full month name (in-date / format context)
-	ShortMonths MonthNames // %b, %h — abbreviated month name (format context)
-
-	StandaloneMonths      MonthNames // reserved for %OB — full, stand-alone context
-	StandaloneShortMonths MonthNames // reserved for %Ob — abbreviated, stand-alone
-
-	Weekdays      WeekdayNames // %A — full weekday name
-	ShortWeekdays WeekdayNames // %a — abbreviated weekday name
-
-	AMPM [2]string // %p — index 0 for hours before noon, 1 for noon onward
+// Some languages (Russian, Czech, Polish, Greek, ...) inflect a month name
+// depending on whether it stands alone or sits next to a day number — e.g.
+// Russian "январь" (stand-alone) vs "2 января" (in a date). A Locale returns a
+// single form per month, so format each grammatical context with its own
+// Strftime object, each compiled with the Locale that holds the matching form.
+type Locale interface {
+	Month(time.Month) string          // full month name (%B)
+	ShortMonth(time.Month) string     // abbreviated month name (%b, %h)
+	Weekday(time.Weekday) string      // full weekday name (%A)
+	ShortWeekday(time.Weekday) string // abbreviated weekday name (%a)
+	Meridiem(hour int) string         // AM/PM marker for the given 0-23 hour (%p)
 }
 
-// DefaultLocale returns the English locale, derived entirely from the
-// standard library's time package. It is a convenient starting point if you
-// want to override only some of the names.
-func DefaultLocale() Locale {
-	var l Locale
+// localeData is the array-backed Locale implementation produced by NewLocale
+// and DefaultLocale. Its fields are unexported and never mutated after
+// construction, so a Locale is safe to share across goroutines.
+type localeData struct {
+	months        [12]string
+	shortMonths   [12]string
+	weekdays      [7]string
+	shortWeekdays [7]string
+	meridiem      [2]string
+}
+
+func (d *localeData) Month(m time.Month) string          { return d.months[int(m)-1] }
+func (d *localeData) ShortMonth(m time.Month) string     { return d.shortMonths[int(m)-1] }
+func (d *localeData) Weekday(w time.Weekday) string      { return d.weekdays[int(w)] }
+func (d *localeData) ShortWeekday(w time.Weekday) string { return d.shortWeekdays[int(w)] }
+
+func (d *localeData) Meridiem(hour int) string {
+	if hour < 12 {
+		return d.meridiem[0]
+	}
+	return d.meridiem[1]
+}
+
+// englishLocaleData builds the English locale entirely from the standard
+// library's time package, so no name data is hard-coded here.
+func englishLocaleData() *localeData {
+	d := &localeData{meridiem: [2]string{"AM", "PM"}}
 	for m := time.January; m <= time.December; m++ {
 		full := m.String()
-		l.Months[m-1] = full
-		l.ShortMonths[m-1] = full[:3]
-		l.StandaloneMonths[m-1] = full
-		l.StandaloneShortMonths[m-1] = full[:3]
+		d.months[m-1] = full
+		d.shortMonths[m-1] = full[:3]
 	}
-	for d := time.Sunday; d <= time.Saturday; d++ {
-		full := d.String()
-		l.Weekdays[d] = full
-		l.ShortWeekdays[d] = full[:3]
+	for w := time.Sunday; w <= time.Saturday; w++ {
+		full := w.String()
+		d.weekdays[w] = full
+		d.shortWeekdays[w] = full[:3]
 	}
-	l.AMPM = [2]string{"AM", "PM"}
-	return l
+	return d
 }
 
-// mergeLocale overlays the non-empty entries of loc onto the English default,
-// so any name the caller did not provide degrades to English rather than to
-// an empty string. The result lives on the heap and is pointed into by the
-// appenders created in applyLocale, keeping it alive for their lifetime.
-func mergeLocale(loc Locale) *Locale {
-	merged := DefaultLocale()
-	overlayMonths(&merged.Months, loc.Months)
-	overlayMonths(&merged.ShortMonths, loc.ShortMonths)
-	overlayMonths(&merged.StandaloneMonths, loc.StandaloneMonths)
-	overlayMonths(&merged.StandaloneShortMonths, loc.StandaloneShortMonths)
-	overlayWeekdays(&merged.Weekdays, loc.Weekdays)
-	overlayWeekdays(&merged.ShortWeekdays, loc.ShortWeekdays)
-	for i, v := range loc.AMPM {
-		if v != "" {
-			merged.AMPM[i] = v
+// DefaultLocale returns the English locale. It is the fallback for any name a
+// custom Locale leaves unset, and a convenient base for NewLocale.
+func DefaultLocale() Locale {
+	return englishLocaleData()
+}
+
+// LocaleOption configures a Locale built by NewLocale.
+type LocaleOption interface {
+	configureLocale(*localeData)
+}
+
+type localeOptionFunc func(*localeData)
+
+func (f localeOptionFunc) configureLocale(d *localeData) { f(d) }
+
+// NewLocale creates a Locale from the supplied options, starting from the
+// English locale. Any name an option leaves as the empty string keeps its
+// English default, so a partially-specified Locale never produces blank
+// output.
+func NewLocale(options ...LocaleOption) Locale {
+	d := englishLocaleData()
+	for _, o := range options {
+		o.configureLocale(d)
+	}
+	return d
+}
+
+// WithMonths sets the full month names (%B), indexed by time.Month minus one.
+func WithMonths(names MonthNames) LocaleOption {
+	return localeOptionFunc(func(d *localeData) { overlay12(&d.months, names) })
+}
+
+// WithShortMonths sets the abbreviated month names (%b, %h).
+func WithShortMonths(names MonthNames) LocaleOption {
+	return localeOptionFunc(func(d *localeData) { overlay12(&d.shortMonths, names) })
+}
+
+// WithWeekdays sets the full weekday names (%A), indexed by time.Weekday.
+func WithWeekdays(names WeekdayNames) LocaleOption {
+	return localeOptionFunc(func(d *localeData) { overlay7(&d.weekdays, names) })
+}
+
+// WithShortWeekdays sets the abbreviated weekday names (%a).
+func WithShortWeekdays(names WeekdayNames) LocaleOption {
+	return localeOptionFunc(func(d *localeData) { overlay7(&d.shortWeekdays, names) })
+}
+
+// WithMeridiem sets the AM/PM markers (%p). An empty string keeps the English
+// default for that marker.
+func WithMeridiem(am, pm string) LocaleOption {
+	return localeOptionFunc(func(d *localeData) {
+		if am != "" {
+			d.meridiem[0] = am
 		}
-	}
-	return &merged
+		if pm != "" {
+			d.meridiem[1] = pm
+		}
+	})
 }
 
-func overlayMonths(dst *MonthNames, src MonthNames) {
+func overlay12(dst *[12]string, src MonthNames) {
 	for i, v := range src {
 		if v != "" {
 			dst[i] = v
@@ -97,7 +146,7 @@ func overlayMonths(dst *MonthNames, src MonthNames) {
 	}
 }
 
-func overlayWeekdays(dst *WeekdayNames, src WeekdayNames) {
+func overlay7(dst *[7]string, src WeekdayNames) {
 	for i, v := range src {
 		if v != "" {
 			dst[i] = v
@@ -108,17 +157,17 @@ func overlayWeekdays(dst *WeekdayNames, src WeekdayNames) {
 // applyLocale registers the name-producing appenders that read from loc onto
 // the specification set. It is invoked before any explicit WithSpecification
 // overrides, so a caller can still replace an individual specifier.
-func applyLocale(ds SpecificationSet, loc *Locale) error {
+func applyLocale(ds SpecificationSet, loc Locale) error {
 	pairs := []struct {
 		b byte
 		a Appender
 	}{
-		{'A', weekdayName{names: &loc.Weekdays}},
-		{'a', weekdayName{names: &loc.ShortWeekdays}},
-		{'B', monthName{names: &loc.Months}},
-		{'b', monthName{names: &loc.ShortMonths}},
-		{'h', monthName{names: &loc.ShortMonths}},
-		{'p', ampmName{names: &loc.AMPM}},
+		{'A', weekdayNameAppender{loc: loc}},
+		{'a', weekdayNameAppender{loc: loc, short: true}},
+		{'B', monthNameAppender{loc: loc}},
+		{'b', monthNameAppender{loc: loc, short: true}},
+		{'h', monthNameAppender{loc: loc, short: true}},
+		{'p', meridiemAppender{loc: loc}},
 	}
 	for _, p := range pairs {
 		if err := ds.Set(p.b, p.a); err != nil {
@@ -128,41 +177,46 @@ func applyLocale(ds SpecificationSet, loc *Locale) error {
 	return nil
 }
 
-type monthName struct {
-	names *MonthNames
+type monthNameAppender struct {
+	loc   Locale
+	short bool
 }
 
-func (v monthName) Append(b []byte, t time.Time) []byte {
-	return append(b, v.names[int(t.Month())-1]...)
-}
-
-func (v monthName) dump(out io.Writer) {
-	fmt.Fprintf(out, "monthName")
-}
-
-type weekdayName struct {
-	names *WeekdayNames
-}
-
-func (v weekdayName) Append(b []byte, t time.Time) []byte {
-	return append(b, v.names[int(t.Weekday())]...)
-}
-
-func (v weekdayName) dump(out io.Writer) {
-	fmt.Fprintf(out, "weekdayName")
-}
-
-type ampmName struct {
-	names *[2]string
-}
-
-func (v ampmName) Append(b []byte, t time.Time) []byte {
-	if t.Hour() < 12 {
-		return append(b, v.names[0]...)
+func (v monthNameAppender) Append(b []byte, t time.Time) []byte {
+	if v.short {
+		return append(b, v.loc.ShortMonth(t.Month())...)
 	}
-	return append(b, v.names[1]...)
+	return append(b, v.loc.Month(t.Month())...)
 }
 
-func (v ampmName) dump(out io.Writer) {
-	fmt.Fprintf(out, "ampmName")
+func (v monthNameAppender) dump(out io.Writer) {
+	fmt.Fprintf(out, "monthName(short=%t)", v.short)
+}
+
+type weekdayNameAppender struct {
+	loc   Locale
+	short bool
+}
+
+func (v weekdayNameAppender) Append(b []byte, t time.Time) []byte {
+	if v.short {
+		return append(b, v.loc.ShortWeekday(t.Weekday())...)
+	}
+	return append(b, v.loc.Weekday(t.Weekday())...)
+}
+
+func (v weekdayNameAppender) dump(out io.Writer) {
+	fmt.Fprintf(out, "weekdayName(short=%t)", v.short)
+}
+
+type meridiemAppender struct {
+	loc Locale
+}
+
+func (v meridiemAppender) Append(b []byte, t time.Time) []byte {
+	return append(b, v.loc.Meridiem(t.Hour())...)
+}
+
+func (v meridiemAppender) dump(out io.Writer) {
+	fmt.Fprintf(out, "meridiem")
 }

--- a/locale.go
+++ b/locale.go
@@ -1,0 +1,168 @@
+package strftime
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// MonthNames holds the twelve localized month names, indexed by
+// time.Month minus one (January is index 0, December is index 11).
+type MonthNames [12]string
+
+// WeekdayNames holds the seven localized weekday names, indexed by
+// time.Weekday (Sunday is index 0, Saturday is index 6).
+type WeekdayNames [7]string
+
+// Locale carries the locale-dependent strings used by the name-producing
+// conversion specifiers (%A, %a, %B, %b, %h, %p). It contains no logic and
+// no external data: you populate it with the names for your language and
+// pass it via WithLocale.
+//
+// Month and weekday names are split into a "format" context and a
+// "stand-alone" context. In many languages (Russian, Czech, Polish, Greek,
+// ...) a month name takes a different grammatical form when it appears next
+// to a day number ("2 января") than when it stands alone ("январь"). The
+// format fields (Months, ShortMonths) hold the in-date form; the standalone
+// fields hold the nominative form.
+//
+// Only the format fields are currently reachable through the standard
+// conversion specifiers. To format the two contexts correctly today, compile
+// two Strftime objects with two Locales — one whose Months hold the in-date
+// form for patterns like "%-d %B", and one whose Months hold the stand-alone
+// form for patterns like "%B %Y". The standalone fields are reserved for a
+// future %OB/%Ob specifier and may be left zero if you do not need them.
+//
+// Any entry left as the empty string falls back to the English default, so a
+// partially-filled Locale never produces blank output.
+type Locale struct {
+	Months      MonthNames // %B — full month name (in-date / format context)
+	ShortMonths MonthNames // %b, %h — abbreviated month name (format context)
+
+	StandaloneMonths      MonthNames // reserved for %OB — full, stand-alone context
+	StandaloneShortMonths MonthNames // reserved for %Ob — abbreviated, stand-alone
+
+	Weekdays      WeekdayNames // %A — full weekday name
+	ShortWeekdays WeekdayNames // %a — abbreviated weekday name
+
+	AMPM [2]string // %p — index 0 for hours before noon, 1 for noon onward
+}
+
+// DefaultLocale returns the English locale, derived entirely from the
+// standard library's time package. It is a convenient starting point if you
+// want to override only some of the names.
+func DefaultLocale() Locale {
+	var l Locale
+	for m := time.January; m <= time.December; m++ {
+		full := m.String()
+		l.Months[m-1] = full
+		l.ShortMonths[m-1] = full[:3]
+		l.StandaloneMonths[m-1] = full
+		l.StandaloneShortMonths[m-1] = full[:3]
+	}
+	for d := time.Sunday; d <= time.Saturday; d++ {
+		full := d.String()
+		l.Weekdays[d] = full
+		l.ShortWeekdays[d] = full[:3]
+	}
+	l.AMPM = [2]string{"AM", "PM"}
+	return l
+}
+
+// mergeLocale overlays the non-empty entries of loc onto the English default,
+// so any name the caller did not provide degrades to English rather than to
+// an empty string. The result lives on the heap and is pointed into by the
+// appenders created in applyLocale, keeping it alive for their lifetime.
+func mergeLocale(loc Locale) *Locale {
+	merged := DefaultLocale()
+	overlayMonths(&merged.Months, loc.Months)
+	overlayMonths(&merged.ShortMonths, loc.ShortMonths)
+	overlayMonths(&merged.StandaloneMonths, loc.StandaloneMonths)
+	overlayMonths(&merged.StandaloneShortMonths, loc.StandaloneShortMonths)
+	overlayWeekdays(&merged.Weekdays, loc.Weekdays)
+	overlayWeekdays(&merged.ShortWeekdays, loc.ShortWeekdays)
+	for i, v := range loc.AMPM {
+		if v != "" {
+			merged.AMPM[i] = v
+		}
+	}
+	return &merged
+}
+
+func overlayMonths(dst *MonthNames, src MonthNames) {
+	for i, v := range src {
+		if v != "" {
+			dst[i] = v
+		}
+	}
+}
+
+func overlayWeekdays(dst *WeekdayNames, src WeekdayNames) {
+	for i, v := range src {
+		if v != "" {
+			dst[i] = v
+		}
+	}
+}
+
+// applyLocale registers the name-producing appenders that read from loc onto
+// the specification set. It is invoked before any explicit WithSpecification
+// overrides, so a caller can still replace an individual specifier.
+func applyLocale(ds SpecificationSet, loc *Locale) error {
+	pairs := []struct {
+		b byte
+		a Appender
+	}{
+		{'A', weekdayName{names: &loc.Weekdays}},
+		{'a', weekdayName{names: &loc.ShortWeekdays}},
+		{'B', monthName{names: &loc.Months}},
+		{'b', monthName{names: &loc.ShortMonths}},
+		{'h', monthName{names: &loc.ShortMonths}},
+		{'p', ampmName{names: &loc.AMPM}},
+	}
+	for _, p := range pairs {
+		if err := ds.Set(p.b, p.a); err != nil {
+			return fmt.Errorf("failed to apply locale for %%%c: %w", p.b, err)
+		}
+	}
+	return nil
+}
+
+type monthName struct {
+	names *MonthNames
+}
+
+func (v monthName) Append(b []byte, t time.Time) []byte {
+	return append(b, v.names[int(t.Month())-1]...)
+}
+
+func (v monthName) dump(out io.Writer) {
+	fmt.Fprintf(out, "monthName")
+}
+
+type weekdayName struct {
+	names *WeekdayNames
+}
+
+func (v weekdayName) Append(b []byte, t time.Time) []byte {
+	return append(b, v.names[int(t.Weekday())]...)
+}
+
+func (v weekdayName) dump(out io.Writer) {
+	fmt.Fprintf(out, "weekdayName")
+}
+
+type ampmName struct {
+	names *[2]string
+}
+
+func (v ampmName) Append(b []byte, t time.Time) []byte {
+	if t.Hour() < 12 {
+		return append(b, v.names[0]...)
+	}
+	return append(b, v.names[1]...)
+}
+
+func (v ampmName) dump(out io.Writer) {
+	fmt.Fprintf(out, "ampmName")
+}

--- a/locale_test.go
+++ b/locale_test.go
@@ -9,22 +9,22 @@ import (
 )
 
 // french is a representative non-inflecting locale.
-var french = strftime.Locale{
-	Months: strftime.MonthNames{
+var french = strftime.NewLocale(
+	strftime.WithMonths(strftime.MonthNames{
 		"janvier", "février", "mars", "avril", "mai", "juin",
 		"juillet", "août", "septembre", "octobre", "novembre", "décembre",
-	},
-	ShortMonths: strftime.MonthNames{
+	}),
+	strftime.WithShortMonths(strftime.MonthNames{
 		"janv.", "févr.", "mars", "avr.", "mai", "juin",
 		"juil.", "août", "sept.", "oct.", "nov.", "déc.",
-	},
-	Weekdays: strftime.WeekdayNames{
+	}),
+	strftime.WithWeekdays(strftime.WeekdayNames{
 		"dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
-	},
-	ShortWeekdays: strftime.WeekdayNames{
+	}),
+	strftime.WithShortWeekdays(strftime.WeekdayNames{
 		"dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam.",
-	},
-}
+	}),
+)
 
 // 2006-01-02 03:04:05 UTC is a Monday in January, before noon.
 var locref = time.Date(2006, time.January, 2, 3, 4, 5, 0, time.UTC)
@@ -52,11 +52,11 @@ func TestLocaleFrench(t *testing.T) {
 // A Locale that sets only weekday names must still produce English month
 // names rather than blanks.
 func TestLocalePartialFallback(t *testing.T) {
-	partial := strftime.Locale{
-		Weekdays: strftime.WeekdayNames{
+	partial := strftime.NewLocale(
+		strftime.WithWeekdays(strftime.WeekdayNames{
 			"dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
-		},
-	}
+		}),
+	)
 	got, err := strftime.Format("%A %B", locref, strftime.WithLocale(partial))
 	require.NoError(t, err)
 	require.Equal(t, "lundi January", got)
@@ -80,7 +80,7 @@ func TestLocaleDefaultMatchesEnglish(t *testing.T) {
 }
 
 func TestLocaleAMPM(t *testing.T) {
-	loc := strftime.Locale{AMPM: [2]string{"matin", "soir"}}
+	loc := strftime.NewLocale(strftime.WithMeridiem("matin", "soir"))
 	morning, err := strftime.Format("%p", locref, strftime.WithLocale(loc)) // 03:04 -> morning
 	require.NoError(t, err)
 	require.Equal(t, "matin", morning)
@@ -104,24 +104,20 @@ func TestLocaleExplicitSpecificationOverrides(t *testing.T) {
 // Inflecting languages: the correct in-date vs stand-alone form is selected
 // by compiling one Strftime per context, each with the matching Locale.
 func TestLocaleInflectionViaObjectSwap(t *testing.T) {
-	base := strftime.Locale{
-		Weekdays: strftime.WeekdayNames{
-			"воскресенье", "понедельник", "вторник", "среда",
-			"четверг", "пятница", "суббота",
-		},
-	}
+	weekdays := strftime.WithWeekdays(strftime.WeekdayNames{
+		"воскресенье", "понедельник", "вторник", "среда",
+		"четверг", "пятница", "суббота",
+	})
 
-	inDate := base
-	inDate.Months = strftime.MonthNames{
+	inDate := strftime.NewLocale(weekdays, strftime.WithMonths(strftime.MonthNames{
 		"января", "февраля", "марта", "апреля", "мая", "июня",
 		"июля", "августа", "сентября", "октября", "ноября", "декабря",
-	}
+	}))
 
-	standalone := base
-	standalone.Months = strftime.MonthNames{
+	standalone := strftime.NewLocale(weekdays, strftime.WithMonths(strftime.MonthNames{
 		"январь", "февраль", "март", "апрель", "май", "июнь",
 		"июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь",
-	}
+	}))
 
 	dateFmt, err := strftime.New("%d %B %Y", strftime.WithLocale(inDate))
 	require.NoError(t, err)

--- a/locale_test.go
+++ b/locale_test.go
@@ -1,0 +1,133 @@
+package strftime_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/strftime"
+	"github.com/stretchr/testify/require"
+)
+
+// french is a representative non-inflecting locale.
+var french = strftime.Locale{
+	Months: strftime.MonthNames{
+		"janvier", "février", "mars", "avril", "mai", "juin",
+		"juillet", "août", "septembre", "octobre", "novembre", "décembre",
+	},
+	ShortMonths: strftime.MonthNames{
+		"janv.", "févr.", "mars", "avr.", "mai", "juin",
+		"juil.", "août", "sept.", "oct.", "nov.", "déc.",
+	},
+	Weekdays: strftime.WeekdayNames{
+		"dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
+	},
+	ShortWeekdays: strftime.WeekdayNames{
+		"dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam.",
+	},
+}
+
+// 2006-01-02 03:04:05 UTC is a Monday in January, before noon.
+var locref = time.Date(2006, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+func TestLocaleFrench(t *testing.T) {
+	for _, tc := range []struct {
+		pattern string
+		want    string
+	}{
+		{"%A", "lundi"},
+		{"%a", "lun."},
+		{"%B", "janvier"},
+		{"%b", "janv."},
+		{"%h", "janv."},
+		{"%A %d %B %Y", "lundi 02 janvier 2006"},
+	} {
+		t.Run(tc.pattern, func(t *testing.T) {
+			got, err := strftime.Format(tc.pattern, locref, strftime.WithLocale(french))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// A Locale that sets only weekday names must still produce English month
+// names rather than blanks.
+func TestLocalePartialFallback(t *testing.T) {
+	partial := strftime.Locale{
+		Weekdays: strftime.WeekdayNames{
+			"dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
+		},
+	}
+	got, err := strftime.Format("%A %B", locref, strftime.WithLocale(partial))
+	require.NoError(t, err)
+	require.Equal(t, "lundi January", got)
+}
+
+// Numeric specifiers are locale-invariant.
+func TestLocaleNumericUnaffected(t *testing.T) {
+	got, err := strftime.Format("%Y-%m-%d %H:%M:%S", locref, strftime.WithLocale(french))
+	require.NoError(t, err)
+	require.Equal(t, "2006-01-02 03:04:05", got)
+}
+
+// DefaultLocale reproduces the stock English output.
+func TestLocaleDefaultMatchesEnglish(t *testing.T) {
+	const pattern = "%A %a %B %b %p"
+	english, err := strftime.Format(pattern, locref)
+	require.NoError(t, err)
+	withDefault, err := strftime.Format(pattern, locref, strftime.WithLocale(strftime.DefaultLocale()))
+	require.NoError(t, err)
+	require.Equal(t, english, withDefault)
+}
+
+func TestLocaleAMPM(t *testing.T) {
+	loc := strftime.Locale{AMPM: [2]string{"matin", "soir"}}
+	morning, err := strftime.Format("%p", locref, strftime.WithLocale(loc)) // 03:04 -> morning
+	require.NoError(t, err)
+	require.Equal(t, "matin", morning)
+
+	afternoon := time.Date(2006, time.January, 2, 15, 0, 0, 0, time.UTC)
+	evening, err := strftime.Format("%p", afternoon, strftime.WithLocale(loc))
+	require.NoError(t, err)
+	require.Equal(t, "soir", evening)
+}
+
+// WithSpecification applied alongside WithLocale must win.
+func TestLocaleExplicitSpecificationOverrides(t *testing.T) {
+	got, err := strftime.Format("%B", locref,
+		strftime.WithLocale(french),
+		strftime.WithSpecification('B', strftime.Verbatim("OVERRIDE")),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "OVERRIDE", got)
+}
+
+// Inflecting languages: the correct in-date vs stand-alone form is selected
+// by compiling one Strftime per context, each with the matching Locale.
+func TestLocaleInflectionViaObjectSwap(t *testing.T) {
+	base := strftime.Locale{
+		Weekdays: strftime.WeekdayNames{
+			"воскресенье", "понедельник", "вторник", "среда",
+			"четверг", "пятница", "суббота",
+		},
+	}
+
+	inDate := base
+	inDate.Months = strftime.MonthNames{
+		"января", "февраля", "марта", "апреля", "мая", "июня",
+		"июля", "августа", "сентября", "октября", "ноября", "декабря",
+	}
+
+	standalone := base
+	standalone.Months = strftime.MonthNames{
+		"январь", "февраль", "март", "апрель", "май", "июнь",
+		"июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь",
+	}
+
+	dateFmt, err := strftime.New("%d %B %Y", strftime.WithLocale(inDate))
+	require.NoError(t, err)
+	require.Equal(t, "02 января 2006", dateFmt.FormatString(locref))
+
+	headerFmt, err := strftime.New("%B %Y", strftime.WithLocale(standalone))
+	require.NoError(t, err)
+	require.Equal(t, "январь 2006", headerFmt.FormatString(locref))
+}

--- a/options.go
+++ b/options.go
@@ -23,6 +23,24 @@ func WithSpecificationSet(ds SpecificationSet) Option {
 	}
 }
 
+const optLocale = `opt-locale`
+
+// WithLocale overrides the name-producing conversion specifiers (%A, %a, %B,
+// %b, %h, %p) with the localized names carried by loc. Any name left empty in
+// loc falls back to the English default. Numeric specifiers (%d, %m, %Y, ...)
+// are locale-invariant and are unaffected.
+//
+// Because a single Locale supplies one form per name, format a context that
+// needs inflected month names (e.g. "%-d %B" vs "%B %Y" in Slavic languages)
+// by compiling a separate Strftime object per context, each with the Locale
+// holding the appropriate form. See the Locale documentation for details.
+func WithLocale(loc Locale) Option {
+	return &option{
+		name:  optLocale,
+		value: loc,
+	}
+}
+
 type optSpecificationPair struct {
 	name     byte
 	appender Appender

--- a/options.go
+++ b/options.go
@@ -26,13 +26,13 @@ func WithSpecificationSet(ds SpecificationSet) Option {
 const optLocale = `opt-locale`
 
 // WithLocale overrides the name-producing conversion specifiers (%A, %a, %B,
-// %b, %h, %p) with the localized names carried by loc. Any name left empty in
-// loc falls back to the English default. Numeric specifiers (%d, %m, %Y, ...)
-// are locale-invariant and are unaffected.
+// %b, %h, %p) with the localized names supplied by loc, which is typically
+// built with NewLocale. Numeric specifiers (%d, %m, %Y, ...) are
+// locale-invariant and are unaffected.
 //
-// Because a single Locale supplies one form per name, format a context that
-// needs inflected month names (e.g. "%-d %B" vs "%B %Y" in Slavic languages)
-// by compiling a separate Strftime object per context, each with the Locale
+// Because a Locale supplies one form per name, format a context that needs
+// inflected month names (e.g. "%d %B" vs "%B %Y" in Slavic languages) by
+// compiling a separate Strftime object per context, each with the Locale
 // holding the appropriate form. See the Locale documentation for details.
 func WithLocale(loc Locale) Option {
 	return &option{

--- a/strftime.go
+++ b/strftime.go
@@ -74,6 +74,7 @@ func compile(handler compileHandler, p string, ds SpecificationSet) error {
 func getSpecificationSetFor(options ...Option) (SpecificationSet, error) {
 	ds := defaultSpecificationSet
 	var extraSpecifications []*optSpecificationPair
+	var locale *Locale
 	for _, option := range options {
 		switch option.Name() {
 		case optSpecificationSet:
@@ -84,14 +85,25 @@ func getSpecificationSetFor(options ...Option) (SpecificationSet, error) {
 			if v, ok := option.Value().(*optSpecificationPair); ok {
 				extraSpecifications = append(extraSpecifications, v)
 			}
+		case optLocale:
+			if v, ok := option.Value().(Locale); ok {
+				locale = mergeLocale(v)
+			}
 		}
 	}
 
-	if len(extraSpecifications) > 0 {
+	if locale != nil || len(extraSpecifications) > 0 {
 		// If ds is immutable, we're going to need to create a new
 		// one. oh what a waste!
 		if raw, ok := ds.(*specificationSet); ok && !raw.mutable {
 			ds = NewSpecificationSet()
+		}
+		// Apply the locale first so an explicit WithSpecification can still
+		// override an individual specifier.
+		if locale != nil {
+			if err := applyLocale(ds, locale); err != nil {
+				return nil, err
+			}
 		}
 		for _, v := range extraSpecifications {
 			if err := ds.Set(v.name, v.appender); err != nil {

--- a/strftime.go
+++ b/strftime.go
@@ -74,7 +74,7 @@ func compile(handler compileHandler, p string, ds SpecificationSet) error {
 func getSpecificationSetFor(options ...Option) (SpecificationSet, error) {
 	ds := defaultSpecificationSet
 	var extraSpecifications []*optSpecificationPair
-	var locale *Locale
+	var locale Locale
 	for _, option := range options {
 		switch option.Name() {
 		case optSpecificationSet:
@@ -87,7 +87,7 @@ func getSpecificationSetFor(options ...Option) (SpecificationSet, error) {
 			}
 		case optLocale:
 			if v, ok := option.Value().(Locale); ok {
-				locale = mergeLocale(v)
+				locale = v
 			}
 		}
 	}


### PR DESCRIPTION
- add `WithLocale(Locale)` to localize name specifiers `%A %a %B %b %h %p`; numeric specifiers unaffected
- `Locale` is an interface built via `NewLocale(...)` functional options; English default derived from stdlib `time`, empty entries fall back to English
- inflected languages (format vs stand-alone month forms) handled by compiling one `Strftime` per context; a future `%OB`/`%Ob` can be added as an optional interface without breaking the API

Note: this ships **no actual localizations** — the library carries no per-language name data. It provides the escape hatch so users can supply their own names (or implement `Locale` themselves, backed by a map / computed values / an external dataset).

Closes #64
